### PR TITLE
feat(codex): init-devcontainer スキルを codex/skills に追加 & v1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "AI駆動開発チームのための汎用ハーネスプラグイン",
   "author": {
     "name": "masanami"

--- a/codex/skills/init-devcontainer/SKILL.md
+++ b/codex/skills/init-devcontainer/SKILL.md
@@ -49,7 +49,7 @@ description: "devcontainer環境を構築する設定ファイルを生成する
 | コンテナ名 | `{プロジェクト名} Sandbox` |
 | ベースイメージ | 手順2で検出したイメージ |
 | features | git、および言語に応じた feature |
-| postCreateCommand | Claude Code のインストール + `claude-settings.json` を `~/.claude/settings.json` にコピー + 手順2で検出したシステムツールのインストール |
+| postCreateCommand | Claude Code のインストール + `/workspace/.devcontainer/claude-settings.json` を `~/.claude/settings.json` にコピー + 手順2で検出したシステムツールのインストール |
 | マウント | ローカルワークスペースを `/workspace` にバインド |
 | workspaceFolder | `/workspace` |
 | 環境変数 | `ANTHROPIC_API_KEY` をローカル環境から引き継ぐ |
@@ -67,7 +67,7 @@ description: "devcontainer環境を構築する設定ファイルを生成する
         "hooks": [
           {
             "type": "command",
-            "command": "DENYLIST_PATH=/workspace/.devcontainer/denylist.conf /workspace/scripts/block-dangerous.sh"
+            "command": "/bin/sh -c 'DENYLIST_PATH=/workspace/.devcontainer/denylist.conf /workspace/scripts/block-dangerous.sh'"
           }
         ]
       }
@@ -127,4 +127,5 @@ networks:
 - VS Code: "Reopen in Container" でコンテナを起動
 - CLI: `devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . codex --dangerously-bypass-approvals-and-sandbox`
 - プロジェクト固有のdenyルールは `.devcontainer/denylist.conf` に追記してください
+- `--dangerously-bypass-approvals-and-sandbox` の安全な運用については [セーフティガイド](../../docs/dangerously-skip-permissions.md) を参照
 ```

--- a/codex/skills/init-devcontainer/SKILL.md
+++ b/codex/skills/init-devcontainer/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: init-devcontainer
+description: "devcontainer環境を構築する設定ファイルを生成する。Triggers on: '$init-devcontainer', '/init-devcontainer', 'devcontainerを設定', 'devcontainer環境を作って'"
+---
+
+# devcontainer 環境構築
+
+プロジェクトを分析し、Claude Code をサンドボックス環境で安全に実行するための devcontainer 設定ファイルを生成します。
+
+---
+
+## 手順
+
+### 1. 既存設定の確認
+
+`.devcontainer/` ディレクトリが既に存在する場合はユーザーに上書き・マージ・中止を確認する。
+
+### 2. プロジェクト情報の検出
+
+言語・パッケージマネージャを検出し、適切なベースイメージと features を決定する。
+
+| 検出結果 | ベースイメージ | 追加 features |
+|---------|-------------|--------------|
+| Node.js | `mcr.microsoft.com/devcontainers/base` | `ghcr.io/devcontainers/features/node` |
+| Python | `mcr.microsoft.com/devcontainers/python` | - |
+| Go | `mcr.microsoft.com/devcontainers/go` | - |
+| Rust | `mcr.microsoft.com/devcontainers/rust` | - |
+| 不明 | `mcr.microsoft.com/devcontainers/base` | - |
+
+さらに、以下を確認してプロジェクトのパッケージ管理外でインストールが必要なシステムツールを探索する。
+
+- `README.md` のセットアップ手順
+- `Makefile` / `scripts/` 内のセットアップ系スクリプト
+- `.github/workflows/` のCI設定（`apt install`、`brew install`、`curl ... | sh` などのパターン）
+- `docs/` 内のセットアップガイド
+
+検出したツールは `postCreateCommand` でのインストールコマンドに含める。
+
+### 3. 設定ファイルの生成
+
+以下のファイルを生成する。
+
+#### `.devcontainer/devcontainer.json`
+
+以下の要件を満たす内容で生成する。最新の devcontainer 仕様に従い、実際のスキーマに合わせて適切なフォーマットで記述すること。
+
+| 設定項目 | 内容 |
+|---------|------|
+| コンテナ名 | `{プロジェクト名} Sandbox` |
+| ベースイメージ | 手順2で検出したイメージ |
+| features | git、および言語に応じた feature |
+| postCreateCommand | Claude Code のインストール + `claude-settings.json` を `~/.claude/settings.json` にコピー + 手順2で検出したシステムツールのインストール |
+| マウント | ローカルワークスペースを `/workspace` にバインド |
+| workspaceFolder | `/workspace` |
+| 環境変数 | `ANTHROPIC_API_KEY` をローカル環境から引き継ぐ |
+
+#### `.devcontainer/claude-settings.json`
+
+`block-dangerous.sh` の PreToolUse フックを設定する。
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DENYLIST_PATH=/workspace/.devcontainer/denylist.conf /workspace/scripts/block-dangerous.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### `scripts/block-dangerous.sh`
+
+ハーネスの `scripts/block-dangerous.sh` をプロジェクトにコピーし、実行権限を付与する。
+これはコンテナ内のフック（`/workspace/scripts/block-dangerous.sh`）から参照される。
+
+#### `.devcontainer/denylist.conf`
+
+`scripts/denylist.conf` をコピーし、プロジェクト固有のルールをユーザーが追加できるようコメントを末尾に追加する。
+
+```conf
+# プロジェクト固有のdenyルールをここに追加
+# 例（パターンとメッセージはタブ文字で区切る）:
+# kubectl[[:space:]]+delete[[:space:]]+namespace[[:space:]]+production	productionネームスペースの削除は実行できません
+```
+
+### 4. ネットワーク制御の確認（オプション）
+
+外部ネットワークを遮断したい場合は `.devcontainer/docker-compose.yml` も生成するか確認する。
+
+```yaml
+services:
+  sandbox:
+    image: {ベースイメージ}
+    volumes:
+      - ../:/workspace:cached
+    networks:
+      - sandbox-net
+
+networks:
+  sandbox-net:
+    driver: bridge
+    internal: true
+```
+
+> **注意**: `internal: true` は外部通信を全て遮断する。`postCreateCommand` でのパッケージインストールが失敗するため、必要なものは事前にイメージに含めること。
+
+### 5. 完了報告
+
+```text
+## devcontainer 環境構築 完了
+
+- 生成ファイル:
+  - `scripts/block-dangerous.sh`
+  - `.devcontainer/devcontainer.json`
+  - `.devcontainer/claude-settings.json`
+  - `.devcontainer/denylist.conf`
+
+次のステップ:
+- VS Code: "Reopen in Container" でコンテナを起動
+- CLI: `devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . claude --dangerously-skip-permissions`
+- プロジェクト固有のdenyルールは `.devcontainer/denylist.conf` に追記してください
+```

--- a/codex/skills/init-devcontainer/SKILL.md
+++ b/codex/skills/init-devcontainer/SKILL.md
@@ -125,6 +125,6 @@ networks:
 
 次のステップ:
 - VS Code: "Reopen in Container" でコンテナを起動
-- CLI: `devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . claude --dangerously-skip-permissions`
+- CLI: `devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . codex --dangerously-bypass-approvals-and-sandbox`
 - プロジェクト固有のdenyルールは `.devcontainer/denylist.conf` に追記してください
 ```

--- a/skills/init-devcontainer/SKILL.md
+++ b/skills/init-devcontainer/SKILL.md
@@ -49,7 +49,7 @@ description: "devcontainer環境を構築する設定ファイルを生成する
 | コンテナ名 | `{プロジェクト名} Sandbox` |
 | ベースイメージ | 手順2で検出したイメージ |
 | features | git、および言語に応じた feature |
-| postCreateCommand | Claude Code のインストール + `claude-settings.json` を `~/.claude/settings.json` にコピー + 手順2で検出したシステムツールのインストール |
+| postCreateCommand | Claude Code のインストール + `/workspace/.devcontainer/claude-settings.json` を `~/.claude/settings.json` にコピー + 手順2で検出したシステムツールのインストール |
 | マウント | ローカルワークスペースを `/workspace` にバインド |
 | workspaceFolder | `/workspace` |
 | 環境変数 | `ANTHROPIC_API_KEY` をローカル環境から引き継ぐ |
@@ -67,7 +67,7 @@ description: "devcontainer環境を構築する設定ファイルを生成する
         "hooks": [
           {
             "type": "command",
-            "command": "DENYLIST_PATH=/workspace/.devcontainer/denylist.conf /workspace/scripts/block-dangerous.sh"
+            "command": "/bin/sh -c 'DENYLIST_PATH=/workspace/.devcontainer/denylist.conf /workspace/scripts/block-dangerous.sh'"
           }
         ]
       }
@@ -114,7 +114,7 @@ networks:
 
 ### 5. 完了報告
 
-```
+```text
 ## devcontainer 環境構築 完了
 
 - 生成ファイル:
@@ -127,4 +127,5 @@ networks:
 - VS Code: "Reopen in Container" でコンテナを起動
 - CLI: `devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . claude --dangerously-skip-permissions`
 - プロジェクト固有のdenyルールは `.devcontainer/denylist.conf` に追記してください
+- `--dangerously-skip-permissions` の安全な運用については [セーフティガイド](../../docs/dangerously-skip-permissions.md) を参照
 ```


### PR DESCRIPTION
## Summary

- PR #8 で追加された `skills/init-devcontainer` が `codex/skills/` に未反映だったため追加
- トリガー文字列に `$init-devcontainer` を追加（Codex CLI 規約）
- plugin.json のマイナーバージョンを `1.1.2` → `1.2.0` にバンプ

## Test plan

- [ ] `codex/skills/init-devcontainer/SKILL.md` が `skills/init-devcontainer/SKILL.md` と内容一致（トリガーの `$` プレフィックス差異を除く）
- [ ] `plugin.json` のバージョンが `1.2.0` であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 開発コンテナ初期化スキルを追加しました。プロジェクト言語の検出、適切な環境イメージの選択、セキュリティ設定の自動生成により、安全な開発環境をセットアップできます。

* **Chores**
  * プラグインバージョンを 1.1.2 から 1.2.0 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->