### PR TITLE
chore: バージョンを 1.6.0 に bump

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-harness",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "AI駆動開発チームのための汎用ハーネスプラグイン",
   "author": {
     "name": "masanami"


### PR DESCRIPTION
## 概要

`reasoning effort の付与 (#24)` と `Codex 対応 ADR (#25)`（PR #26 でマージ済み）を含むリリースのため、プラグインバージョンをマイナー bump。

- `1.5.2` → `1.6.0`
- #24 が `feat`（effort 付与＝機能追加）を含むため semver マイナー

## 変更

- `.claude-plugin/plugin.json` の `version` のみ（他に版番号を持つファイルなし）

Refs #24, #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)