### PR TITLE
feat(scripts): scripts/ 共通基盤の整備と extract-acceptance-criteria.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,26 @@
+# scripts/ 共通規約
+
+`scripts/` 配下の gh 系（GitHub CLI を叩いて決定的な処理を行う）スクリプトが従う共通規約。最初の実例は `format-on-save.sh`（フック）と `extract-acceptance-criteria.sh`（gh 系スクリプト第1号）。後続スクリプトは本規約に従うこと。
+
+## 前提
+
+- bash + jq を前提とする
+- jq 不在時のフォールバック方針は `format-on-save.sh` の防御的スタイルを踏襲する
+  - フックのように「機能をスキップしても実害が小さい」処理は、jq 無しでも簡易パース（`sed` 等）で動かしてよい
+  - `extract-acceptance-criteria.sh` のように JSON 構築そのものが本質のスクリプトは jq 必須とし、**jq 不在時は明示的なエラー JSON を stderr に併記した上で exit 非0**（無言でクラッシュしない・スタックトレースを吐かない）
+
+## 出力規約
+
+- **stdout には JSON を1個だけ出力する**。人間向けメッセージ（進捗・エラー詳細）は stderr に出す
+- 成否は **exit code** で表現する。加えて JSON 側にも機械可読なステータスフィールドを含め、呼び出し元が exit code とJSONの両方から判定できるようにする
+- 「特定できなかった」「対象外だった」は暗黙の空配列・空文字ではなく、**明示的なステータスフィールド**で返す（例: `parse_status: "no_checklist_found"`）。呼び出し側の LLM がこれを見てフォールバック挙動（別手段での抽出など）を判断できるようにするため
+
+## quality-check との整合
+
+`skills/quality-check/SKILL.md` の機械可読 JSON（`{result, auto_fix, gates:{lint:{status,errors,...}, ...}}`）と同じ思想＝**機械可読ステータス（exit code / JSON フィールド）と人間向け詳細（stderr メッセージ）を分離する**、という設計を踏襲する。
+
+## テスト
+
+- gh API 等の外部呼び出しを行う処理と、入力（本文テキスト等）から出力（JSON）を組み立てる純粋なパース処理は**関数として分離**する
+- パース関数はスクリプトを `source` して直接呼び出すことで、外部コマンドを叩かずに単体テストできる作りにする
+- テストは `scripts/tests/` 配下に bash スクリプトとして置き、`bash scripts/tests/xxx.sh` で実行できるようにする。失敗時は非0 exit で終了し、要約を出力する

--- a/scripts/extract-acceptance-criteria.sh
+++ b/scripts/extract-acceptance-criteria.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# extract-acceptance-criteria.sh
+# GitHub Issue本文の「## 受入基準」「## 完了条件」セクションから
+# チェックリスト（- [ ] / - [x]）を抽出し、構造化されたJSONを返す。
+#
+# 使い方:
+#   scripts/extract-acceptance-criteria.sh <issue番号>
+#     -> gh issue view <issue番号> --json body で本文を取得してパースする
+#   scripts/extract-acceptance-criteria.sh --stdin
+#     -> stdin から本文テキストを読み込んでパースする（gh を呼ばない。issue は null）
+#
+# 出力（stdout にJSON1個）:
+#   {"issue": N, "criteria": [{"id": "AC-1", "text": "...", "checked": false}], "parse_status": "ok" | "no_checklist_found"}
+#
+# チェックリストが見つからない場合は parse_status: "no_checklist_found" を返す（exit 0、エラー終了しない）。
+# gh 呼び出し自体の失敗・jq 不在など真の異常系は stderr にメッセージを出し、exit 非0 で終了する。
+#
+# テスト容易性のため、本文取得（fetch_issue_body）とパース（parse_acceptance_criteria）を
+# 関数として分離している。このファイルを `source` すれば gh を呼ばずに
+# parse_acceptance_criteria を直接テストできる。
+
+set -u
+
+# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
+check_jq() {
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but was not found in PATH" >&2
+    printf '{"error":"jq not found"}\n' >&2
+    return 1
+  fi
+  return 0
+}
+
+# gh issue view で Issue 本文を取得する。
+# 引数: Issue番号
+# 戻り値: 本文テキストを stdout に出力（呼び出し側で $() キャプチャする）。失敗時は非0を返す。
+fetch_issue_body() {
+  local issue_num="$1"
+  local output
+  if ! output=$(gh issue view "$issue_num" --json body -q .body 2>&1); then
+    echo "Error: failed to fetch issue #${issue_num} via gh: ${output}" >&2
+    return 1
+  fi
+  printf '%s' "$output"
+}
+
+# 本文テキストから「## 受入基準」「## 完了条件」セクション配下の
+# チェックリスト行を抽出し、結果をグローバル変数 PARSE_STATUS / CRITERIA_JSON に格納する。
+# gh を呼ばない純粋関数。引数または stdin で本文テキストを受け取る。
+#
+# 使い方:
+#   parse_acceptance_criteria "$body_text"
+#   echo "$body_text" | parse_acceptance_criteria
+parse_acceptance_criteria() {
+  local body
+  if [ "$#" -ge 1 ]; then
+    body="$1"
+  else
+    body="$(cat)"
+  fi
+
+  # gh issue view --json body はCRLF改行の本文を返すことがある。
+  # \r を残したままだと各行末の text に \r が混入するため、先に正規化する。
+  body="${body//$'\r'/}"
+
+  # 「## 受入基準」または「## 完了条件」セクション配下の行だけを抜き出す。
+  # 次の "## " 見出しが来たらキャプチャを止める。
+  # 両方のセクションが同一本文に存在する場合は連番で通しIDを振る（意図的な仕様）。
+  # インデント付き（ネストした）チェックリスト行は対象外（列0の "- [ ]"/"- [x]" のみ抽出）。
+  local section
+  section=$(printf '%s\n' "$body" | awk '
+    /^## (受入基準|完了条件)[[:space:]]*$/ { capture=1; next }
+    /^## / { capture=0 }
+    capture { print }
+  ')
+
+  local criteria_json="[]"
+  local idx=0
+  local status="no_checklist_found"
+  local line mark text id checked
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^-\ \[([xX\ ])\][[:space:]]+(.+)$ ]]; then
+      idx=$((idx + 1))
+      mark="${BASH_REMATCH[1]}"
+      text="${BASH_REMATCH[2]}"
+      if [ "$mark" = "x" ] || [ "$mark" = "X" ]; then
+        checked=true
+      else
+        checked=false
+      fi
+      id="AC-${idx}"
+      criteria_json=$(jq -c --arg id "$id" --arg text "$text" --argjson checked "$checked" \
+        '. + [{"id": $id, "text": $text, "checked": $checked}]' <<<"$criteria_json")
+      status="ok"
+    fi
+  done <<<"$section"
+
+  PARSE_STATUS="$status"
+  CRITERIA_JSON="$criteria_json"
+}
+
+print_usage() {
+  local prog
+  prog="$(basename "$0")"
+  echo "Usage: ${prog} <issue番号>" >&2
+  echo "       ${prog} --stdin   (本文をstdinから読み込む。gh を呼ばない。issueはnullとして出力。テスト・デバッグ用)" >&2
+}
+
+main() {
+  local arg="${1:-}"
+
+  if [ -z "$arg" ]; then
+    print_usage
+    exit 1
+  fi
+
+  if ! check_jq; then
+    exit 1
+  fi
+
+  local issue_json="null"
+  local body
+
+  if [ "$arg" = "--stdin" ]; then
+    body="$(cat)"
+  else
+    if ! [[ "$arg" =~ ^[0-9]+$ ]]; then
+      echo "Error: issue number must be numeric, got '${arg}'" >&2
+      print_usage
+      exit 1
+    fi
+    issue_json="$arg"
+    if ! body="$(fetch_issue_body "$arg")"; then
+      exit 1
+    fi
+  fi
+
+  parse_acceptance_criteria "$body"
+
+  jq -n --argjson issue "$issue_json" --argjson criteria "$CRITERIA_JSON" --arg status "$PARSE_STATUS" \
+    '{issue: $issue, criteria: $criteria, parse_status: $status}'
+}
+
+# `source` された場合は main を実行しない（テストからの関数直接呼び出しを可能にするため）。
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/extract-acceptance-criteria.sh
+++ b/scripts/extract-acceptance-criteria.sh
@@ -36,11 +36,16 @@ check_jq() {
 # 戻り値: 本文テキストを stdout に出力（呼び出し側で $() キャプチャする）。失敗時は非0を返す。
 fetch_issue_body() {
   local issue_num="$1"
-  local output
-  if ! output=$(gh issue view "$issue_num" --json body -q .body 2>&1); then
-    echo "Error: failed to fetch issue #${issue_num} via gh: ${output}" >&2
+  local output stderr_file
+  # stderr を stdout に混ぜない: gh が成功時に出す警告（rate limit 通知等）が
+  # 本文に混入するとセクション誤認の silent failure になるため、別ファイルに分離する。
+  stderr_file="$(mktemp)"
+  if ! output=$(gh issue view "$issue_num" --json body -q .body 2>"$stderr_file"); then
+    echo "Error: failed to fetch issue #${issue_num} via gh: $(cat "$stderr_file")" >&2
+    rm -f "$stderr_file"
     return 1
   fi
+  rm -f "$stderr_file"
   printf '%s' "$output"
 }
 

--- a/scripts/tests/test-extract-acceptance-criteria.sh
+++ b/scripts/tests/test-extract-acceptance-criteria.sh
@@ -95,6 +95,20 @@ read -r -d '' FIXTURE_NO_CHECKLIST <<'EOF'
 よしなに直す。
 EOF
 
+read -r -d '' FIXTURE_BOTH_SECTIONS <<'EOF'
+# 機能 + 実装タスク
+
+## 受入基準
+
+- [ ] ユーザーがログインできる
+- [x] エラーが表示される
+
+## 完了条件
+
+- [ ] APIが実装されている
+- [ ] テストが追加されている
+EOF
+
 echo "=== test: 受入基準セクション（feature-spec形式）からのチェックリスト抽出 ==="
 parse_acceptance_criteria "$FIXTURE_FEATURE_SPEC"
 assert_eq "parse_status が ok" "ok" "$PARSE_STATUS"
@@ -126,6 +140,13 @@ assert_eq "criteria が空配列" "0" "$(jq 'length' <<<"$CRITERIA_JSON")"
 echo "=== test: IDがAC-1からの安定連番であること ==="
 parse_acceptance_criteria "$FIXTURE_IMPLEMENTATION_TICKET"
 assert_eq "全件のidが順にAC-1,AC-2,AC-3" "AC-1 AC-2 AC-3" "$(jq -r '[.[].id] | join(" ")' <<<"$CRITERIA_JSON")"
+
+echo "=== test: 両セクション混在時に通しIDが振られること ==="
+parse_acceptance_criteria "$FIXTURE_BOTH_SECTIONS"
+assert_eq "parse_status が ok" "ok" "$PARSE_STATUS"
+assert_eq "criteria が4件" "4" "$(jq 'length' <<<"$CRITERIA_JSON")"
+assert_eq "全件のidが順にAC-1,AC-2,AC-3,AC-4" "AC-1 AC-2 AC-3 AC-4" "$(jq -r '[.[].id] | join(" ")' <<<"$CRITERIA_JSON")"
+assert_eq "セクション跨ぎでもtextが正しい（3件目=完了条件の1件目）" "APIが実装されている" "$(jq -r '.[2].text' <<<"$CRITERIA_JSON")"
 
 echo "=== test: CRLF改行の本文でも text にCRが混入しない ==="
 FIXTURE_CRLF=$(printf '## 受入基準\r\n\r\n- [ ] ログインできる\r\n- [x] エラーが表示される\r\n')

--- a/scripts/tests/test-extract-acceptance-criteria.sh
+++ b/scripts/tests/test-extract-acceptance-criteria.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# test-extract-acceptance-criteria.sh
+# scripts/extract-acceptance-criteria.sh のパース関数（parse_acceptance_criteria）を
+# gh API を呼ばずに直接テストする。
+#
+# 実行方法: bash scripts/tests/test-extract-acceptance-criteria.sh
+# 失敗時は非0 exitし、失敗したテスト名を要約として出力する。
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SCRIPT="${SCRIPT_DIR}/../extract-acceptance-criteria.sh"
+
+# main() を実行させずに関数だけを読み込む
+# shellcheck source=/dev/null
+source "$TARGET_SCRIPT"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+# --- アサーションヘルパー ---
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$expected" = "$actual" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${description}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("$description")
+    echo "  NG - ${description}"
+    echo "       expected: ${expected}"
+    echo "       actual:   ${actual}"
+  fi
+}
+
+# --- フィクスチャ: feature-spec.md 由来（## 受入基準） ---
+
+read -r -d '' FIXTURE_FEATURE_SPEC <<'EOF'
+# サンプル機能
+
+## 概要
+
+サンプル機能の概要。
+
+## 受入基準
+
+- [ ] ユーザーはログインできる
+- [x] ログイン失敗時にエラーメッセージが表示される
+
+## 参照
+
+- 何かのリンク
+EOF
+
+# --- フィクスチャ: implementation-ticket.md 由来（## 完了条件） ---
+
+read -r -d '' FIXTURE_IMPLEMENTATION_TICKET <<'EOF'
+# タスク名
+
+Parent: #100
+
+## 概要
+
+タスクの概要。
+
+## 完了条件
+
+- [ ] APIエンドポイントが実装されている
+- [ ] 単体テストが追加されている
+- [x] 既存テストがパスする
+
+## 技術的な指示
+
+### 変更対象ファイル
+
+- `src/foo.ts`（新規作成）
+EOF
+
+# --- フィクスチャ: チェックリストが無い本文 ---
+
+read -r -d '' FIXTURE_NO_CHECKLIST <<'EOF'
+# 手書きIssue
+
+## 背景
+
+チェックリストの無い、手で書かれたIssue本文。
+
+## やること
+
+よしなに直す。
+EOF
+
+echo "=== test: 受入基準セクション（feature-spec形式）からのチェックリスト抽出 ==="
+parse_acceptance_criteria "$FIXTURE_FEATURE_SPEC"
+assert_eq "parse_status が ok" "ok" "$PARSE_STATUS"
+assert_eq "criteria が2件" "2" "$(jq 'length' <<<"$CRITERIA_JSON")"
+assert_eq "1件目のid が AC-1" "AC-1" "$(jq -r '.[0].id' <<<"$CRITERIA_JSON")"
+assert_eq "1件目のtext" "ユーザーはログインできる" "$(jq -r '.[0].text' <<<"$CRITERIA_JSON")"
+assert_eq "2件目のid が AC-2" "AC-2" "$(jq -r '.[1].id' <<<"$CRITERIA_JSON")"
+
+echo "=== test: 完了条件セクション（implementation-ticket形式）からのチェックリスト抽出 ==="
+parse_acceptance_criteria "$FIXTURE_IMPLEMENTATION_TICKET"
+assert_eq "parse_status が ok" "ok" "$PARSE_STATUS"
+assert_eq "criteria が3件" "3" "$(jq 'length' <<<"$CRITERIA_JSON")"
+assert_eq "1件目のtext" "APIエンドポイントが実装されている" "$(jq -r '.[0].text' <<<"$CRITERIA_JSON")"
+
+echo "=== test: checked/uncheckedフィールドが正しい ==="
+parse_acceptance_criteria "$FIXTURE_FEATURE_SPEC"
+assert_eq "1件目（- [ ]）は checked=false" "false" "$(jq -r '.[0].checked' <<<"$CRITERIA_JSON")"
+assert_eq "2件目（- [x]）は checked=true" "true" "$(jq -r '.[1].checked' <<<"$CRITERIA_JSON")"
+
+parse_acceptance_criteria "$FIXTURE_IMPLEMENTATION_TICKET"
+assert_eq "3件目（- [x]）は checked=true" "true" "$(jq -r '.[2].checked' <<<"$CRITERIA_JSON")"
+assert_eq "2件目（- [ ]）は checked=false" "false" "$(jq -r '.[1].checked' <<<"$CRITERIA_JSON")"
+
+echo "=== test: チェックリストが無い本文で no_checklist_found ==="
+parse_acceptance_criteria "$FIXTURE_NO_CHECKLIST"
+assert_eq "parse_status が no_checklist_found" "no_checklist_found" "$PARSE_STATUS"
+assert_eq "criteria が空配列" "0" "$(jq 'length' <<<"$CRITERIA_JSON")"
+
+echo "=== test: IDがAC-1からの安定連番であること ==="
+parse_acceptance_criteria "$FIXTURE_IMPLEMENTATION_TICKET"
+assert_eq "全件のidが順にAC-1,AC-2,AC-3" "AC-1 AC-2 AC-3" "$(jq -r '[.[].id] | join(" ")' <<<"$CRITERIA_JSON")"
+
+echo "=== test: CRLF改行の本文でも text にCRが混入しない ==="
+FIXTURE_CRLF=$(printf '## 受入基準\r\n\r\n- [ ] ログインできる\r\n- [x] エラーが表示される\r\n')
+parse_acceptance_criteria "$FIXTURE_CRLF"
+assert_eq "parse_status が ok" "ok" "$PARSE_STATUS"
+assert_eq "1件目のtextにCRが混入していない" "ログインできる" "$(jq -r '.[0].text' <<<"$CRITERIA_JSON")"
+assert_eq "2件目のtextにCRが混入していない" "エラーが表示される" "$(jq -r '.[1].text' <<<"$CRITERIA_JSON")"
+
+echo "=== test: CLIレベル（--stdin, ghを呼ばない）での統合確認 ==="
+CLI_OUTPUT=$(printf '%s' "$FIXTURE_FEATURE_SPEC" | "$TARGET_SCRIPT" --stdin)
+CLI_EXIT=$?
+assert_eq "exit code が 0" "0" "$CLI_EXIT"
+assert_eq "issueフィールドがnull" "null" "$(jq -r '.issue' <<<"$CLI_OUTPUT")"
+assert_eq "parse_statusがok" "ok" "$(jq -r '.parse_status' <<<"$CLI_OUTPUT")"
+assert_eq "criteriaが2件" "2" "$(jq '.criteria | length' <<<"$CLI_OUTPUT")"
+
+echo ""
+echo "=== summary ==="
+echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - ${t}"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## 概要

gh/jq を前提とした scripts/ の共通規約を `scripts/README.md` にドキュメント化し、その第1号として `scripts/extract-acceptance-criteria.sh` を追加する。Issue 本文の「## 受入基準」「## 完了条件」セクション配下のチェックリストを決定的にパースし、構造化 JSON を返す。

## 変更内容

- `scripts/README.md`（新規）: bash+jq前提、stdout=JSON1個/stderr=人間向けメッセージ、機械可読ステータスによる明示的なフォールバック判定、`skills/quality-check` の JSON 出力思想との整合を記載
- `scripts/extract-acceptance-criteria.sh`（新規）: `fetch_issue_body()`（gh依存）と `parse_acceptance_criteria()`（純粋関数）を分離。`--stdin` オプションで gh を呼ばずにテスト可能
  - 出力: `{issue, criteria: [{id, text, checked}], parse_status: "ok" | "no_checklist_found"}`
  - チェックリスト無し本文はエラー終了せず `parse_status: "no_checklist_found"` を返す（exit 0）
  - jq 不在時は明示的エラーJSON(stderr) + exit非0で防御的に失敗
  - CRLF本文の正規化を含む
- `scripts/tests/test-extract-acceptance-criteria.sh`（新規）: 22件のテスト（feature-spec/implementation-ticketテンプレート形式の抽出、checked判定、no_checklist_found、ID連番、CRLF、CLI統合）

## 設計方針

- `extract-acceptance-criteria.sh` は #46（create-ticket）/ #52（昇格前検証）/ #54（create-e2e）から共用する汎用インターフェース。特定スキル固有のロジックは含まない
- `skills/define-feature/templates/feature-spec.md`（受入基準セクション）と `skills/create-ticket/templates/implementation-ticket.md`（完了条件セクション）双方のテンプレート実物で動作確認済み

## テスト

`bash scripts/tests/test-extract-acceptance-criteria.sh` — 22件 pass
shellcheck — エラー0

## 受入基準チェック

- [x] scripts/ の共通規約がドキュメント化されている
- [x] extract-acceptance-criteria.sh が create-ticket テンプレート由来の Issue から `[{id, text, checked}]` を決定的に抽出できる
- [x] チェックリストの無い Issue で `parse_status: no_checklist_found` を返す（エラー終了しない）
- [x] jq 不在環境で防御的に振る舞う（format-on-save.sh と同方針）
- [x] #46 / #52 / #54 から共用できるインターフェースであることを設計上確認済み（実利用は各Issueの実装時）

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * GitHub CLIスクリプトの共通規約ドキュメントを追加

* **New Features**
  * GitHub Issue本文から「受入基準／完了条件」のチェックリストを構造化データ（JSON）として抽出
  * `--stdin` での入力対応、jq未検出時は明確なエラーで終了、CRLF由来の混入を除去

* **Tests**
  * 受入基準抽出機能の単体／CLI統合テストスイートを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->