### PR TITLE
docs(create-e2e): スクリプト仕様正本を scripts/README.md に統一

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,3 +90,45 @@ stdout JSON:
 - 終了コード: `result` が `pass` なら 0、`fail` なら 1。jq 不在は 2、CLI引数不正（未知フラグ・値欠落・`--lint`/`--typecheck`/`--test` の重複指定）は 1（個別メッセージは stderr）。**exit 2（jq不在）の場合は stdout にJSONが出力されない**ため、呼び出し側は exit code を先に確認してから stdout をJSONとしてパースすること
 - `--lint`/`--typecheck`/`--test` はそれぞれ1回のみ指定可（`--auto-fix` は0回以上）。重複指定は無言の上書きを避けるため exit 1 のエラーとする
 - bash 3.2（macOS既定）の `set -u` 下での空配列展開の互換性に配慮した実装になっている（`${arr[@]+"${arr[@]}"}` イディオム）
+## extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様（正本）
+
+`skills/create-e2e/SKILL.md`（Step 1-1, Step 1-3）はこの仕様を参照し、フィールド定義を複製しない。
+
+### extract-acceptance-criteria.sh
+
+`scripts/extract-acceptance-criteria.sh <issue番号>` または `scripts/extract-acceptance-criteria.sh --stdin` の stdout JSON。
+
+| フィールド | 型 / 値 | 意味 |
+|---|---|---|
+| `issue` | number \| null | Issue番号。`--stdin` 呼び出し時は null |
+| `criteria` | `[{id, text, checked}]` | 抽出したチェックリスト項目。`id` は `AC-1` 形式の通しID、`checked` は bool |
+| `parse_status` | `"ok"` \| `"no_checklist_found"` | チェックリストを1件でも抽出できたか |
+
+挙動の要点:
+
+- 使い方は2通り。`<issue番号>` 指定時は `gh issue view <issue番号> --json body` で本文を取得してパースする。`--stdin` 指定時は stdin から本文テキストを読み込んでパースする（gh を呼ばない。`issue` は null）
+- 抽出対象は Issue本文の「## 受入基準」または「## 完了条件」セクション配下の `- [ ]` / `- [x]` チェックリスト行（インデント付きのネスト行は対象外）
+- 両セクションが同一本文に存在する場合は連番で通しIDを振る
+- チェックリストが1件も見つからない場合は `parse_status: "no_checklist_found"` を返す（exit 0、エラー終了しない）
+- gh 呼び出し自体の失敗・jq 不在など真の異常系は stderr にメッセージを出し exit 非0 で終了する
+
+### check-e2e-traceability.sh
+
+`scripts/check-e2e-traceability.sh <criteria_json_file|-> <trace_json_file|->` の stdout JSON。第1引数は `extract-acceptance-criteria.sh` の出力JSON、第2引数はテストケース設計のトレーサビリティ表JSON（`{"cases": [{"name": "...", "class": "正常系", "criteria": ["AC-1", "AC-2"]}]}`）。いずれもファイルパスまたは `-` でstdin指定できるが、両方同時に `-` は不可。
+
+| フィールド | 型 / 値 | 意味 |
+|---|---|---|
+| `uncovered` | `[{id, text}]` | criteria側にあり、どのテストケースにも紐づいていない完了条件 |
+| `unknown_ids` | `[string]` | テストケース側が参照しているが criteria側に存在しないID（幻覚ID） |
+| `status` | `"ok"` \| `"issues_found"` \| `"no_criteria"` | 突合結果の要約 |
+
+`status` の意味:
+
+- `no_criteria`: criteria側の `parse_status` が `no_checklist_found`、または `criteria` 配列が空（「未カバー」概念自体が成立しない）。`uncovered`/`unknown_ids` は空配列
+- `ok`: `uncovered`・`unknown_ids` ともに空
+- `issues_found`: いずれかが非空
+
+挙動の要点:
+
+- exit code は「チェックが正常に実行できたか」を表す。`issues_found` は検知の正常動作なので exit 0
+- 真の異常系（jq不在、入力ファイル不存在、不正JSON、必須キー欠如、両方stdin指定等）は stderr にメッセージを出し exit 非0

--- a/skills/create-e2e/SKILL.md
+++ b/skills/create-e2e/SKILL.md
@@ -36,7 +36,7 @@ effort: medium
 
 > **スクリプトの所在（重要）**: 本スキルはプラグインとして配布されるため、以下で参照するスクリプトは**ユーザーのプロジェクトroot ではなく、プラグイン配下**にある。`${CLAUDE_PLUGIN_ROOT}` は実行時にプラグインルートへ展開される。
 
-- Issue/PRの場合: `gh issue view` / `gh pr view` で本文・完了条件・受入基準を取得する。加えて `bash "${CLAUDE_PLUGIN_ROOT}/scripts/extract-acceptance-criteria.sh" <番号>` で完了条件を機械可読JSON（`{issue, criteria:[{id,text,checked}], parse_status}`）としても取得しておく（後続 Step 1-3 のトレーサビリティチェックの入力になる）。**この `<番号>` は常に Issue 番号**（`extract-acceptance-criteria.sh` は内部で `gh issue view` のみを呼ぶ）。対象がPRの場合は、PR番号をそのまま渡さず、PRに紐づく Issue 番号（`gh pr view <PR番号> --json closingIssuesReferences` 等で特定）を渡す。紐づく Issue が無いPRの場合は Step 1-1 の「機能名」ケースと同様に扱い、このスクリプトチェックは対象外とする
+- Issue/PRの場合: `gh issue view` / `gh pr view` で本文・完了条件・受入基準を取得する。加えて `bash "${CLAUDE_PLUGIN_ROOT}/scripts/extract-acceptance-criteria.sh" <番号>` で完了条件を機械可読JSONとしても取得しておく（後続 Step 1-3 のトレーサビリティチェックの入力になる）。**出力JSON形式の正本は `scripts/README.md`「extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様」を参照し、ここには複製しない**。使うフィールドは `criteria`（各要素の `id`/`text`）と `parse_status`。**この `<番号>` は常に Issue 番号**（`extract-acceptance-criteria.sh` は内部で `gh issue view` のみを呼ぶ）。対象がPRの場合は、PR番号をそのまま渡さず、PRに紐づく Issue 番号（`gh pr view <PR番号> --json closingIssuesReferences` 等で特定）を渡す。紐づく Issue が無いPRの場合は Step 1-1 の「機能名」ケースと同様に扱い、このスクリプトチェックは対象外とする
 - 機能名の場合（Issue番号が無いケース）: 関連チケット・コードを調査して完了条件に相当する期待挙動を特定する。この場合 `extract-acceptance-criteria.sh` は対象外（Issue本文が無いため）であり、Step 1-3 のトレーサビリティチェックも自動実行せず、従来通り目視でのトレーサビリティ表確認にとどめる
 - 設計書がある場合は補助的に参照してよいが、テストケースの根拠は仕様に置く
 - プロジェクトルートの `CLAUDE.md` でテスト方針・E2Eテスト実行コマンドを確認する
@@ -67,7 +67,7 @@ effort: medium
 | {完了条件1} | {テストケース名} |
 | {完了条件2} | （未カバー → 要追加） |
 
-**機械可読チェック（Issue/PRが対象の場合）**: 上記トレーサビリティ表と同じ内容を `{"cases":[{"name":"ログイン成功","class":"正常系","criteria":["AC-1"]}]}` 形式のJSONとしても用意し、`bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-e2e-traceability.sh" <criteria.json> <trace.json>` を実行する。**未カバー0件・未知ID0件を返すまで設計を追補する（上限2周）**。2周しても残る場合はループを打ち切り、残存する未カバー条件・未知IDを**返却内容に明記**したうえで次のPhaseに進む（黙って進めない）。このスクリプトが検証するのは「完了条件とテストケースの対応付けの網羅性」であり、テストが完了条件を意味的に満たしているかの検証ではない（意味的妥当性の検証は `/explain-e2e` の責務）。
+**機械可読チェック（Issue/PRが対象の場合）**: 上記トレーサビリティ表と同じ内容を `cases` 配列のJSONとしても用意し、`bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-e2e-traceability.sh" <criteria.json> <trace.json>` を実行する。**入出力JSON形式の正本は `scripts/README.md`「extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様」を参照し、ここには複製しない**。**未カバー0件・未知ID0件を返すまで設計を追補する（上限2周）**。2周しても残る場合はループを打ち切り、残存する未カバー条件・未知IDを**返却内容に明記**したうえで次のPhaseに進む（黙って進めない）。このスクリプトが検証するのは「完了条件とテストケースの対応付けの網羅性」であり、テストが完了条件を意味的に満たしているかの検証ではない（意味的妥当性の検証は `/explain-e2e` の責務）。
 
 入力が「機能名」（Issue番号が無い）の場合は Step 1-1 の記載の通りこのスクリプトチェックは適用外であり、目視でのトレーサビリティ表作成のみで代替する。
 

--- a/skills/create-e2e/SKILL.md
+++ b/skills/create-e2e/SKILL.md
@@ -36,7 +36,7 @@ effort: medium
 
 > **スクリプトの所在（重要）**: 本スキルはプラグインとして配布されるため、以下で参照するスクリプトは**ユーザーのプロジェクトroot ではなく、プラグイン配下**にある。`${CLAUDE_PLUGIN_ROOT}` は実行時にプラグインルートへ展開される。
 
-- Issue/PRの場合: `gh issue view` / `gh pr view` で本文・完了条件・受入基準を取得する。加えて `bash "${CLAUDE_PLUGIN_ROOT}/scripts/extract-acceptance-criteria.sh" <番号>` で完了条件を機械可読JSONとしても取得しておく（後続 Step 1-3 のトレーサビリティチェックの入力になる）。**出力JSON形式の正本は `scripts/README.md`「extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様」を参照し、ここには複製しない**。使うフィールドは `criteria`（各要素の `id`/`text`）と `parse_status`。**この `<番号>` は常に Issue 番号**（`extract-acceptance-criteria.sh` は内部で `gh issue view` のみを呼ぶ）。対象がPRの場合は、PR番号をそのまま渡さず、PRに紐づく Issue 番号（`gh pr view <PR番号> --json closingIssuesReferences` 等で特定）を渡す。紐づく Issue が無いPRの場合は Step 1-1 の「機能名」ケースと同様に扱い、このスクリプトチェックは対象外とする
+- Issue/PRの場合: `gh issue view` / `gh pr view` で本文・完了条件・受入基準を取得する。加えて `bash "${CLAUDE_PLUGIN_ROOT}/scripts/extract-acceptance-criteria.sh" <番号>` で完了条件を機械可読JSONとしても取得しておく（後続 Step 1-3 のトレーサビリティチェックの入力になる）。**出力JSON形式の正本はプラグイン配下の `scripts/README.md`「extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様」を参照し、ここには複製しない**（Read する場合はスキル起動時の「Base directory for this skill」から `<base>/../../scripts/README.md` として解決する）。使うフィールドは `criteria`（各要素の `id`/`text`）と `parse_status`。**この `<番号>` は常に Issue 番号**（`extract-acceptance-criteria.sh` は内部で `gh issue view` のみを呼ぶ）。対象がPRの場合は、PR番号をそのまま渡さず、PRに紐づく Issue 番号（`gh pr view <PR番号> --json closingIssuesReferences` 等で特定）を渡す。紐づく Issue が無いPRの場合は Step 1-1 の「機能名」ケースと同様に扱い、このスクリプトチェックは対象外とする
 - 機能名の場合（Issue番号が無いケース）: 関連チケット・コードを調査して完了条件に相当する期待挙動を特定する。この場合 `extract-acceptance-criteria.sh` は対象外（Issue本文が無いため）であり、Step 1-3 のトレーサビリティチェックも自動実行せず、従来通り目視でのトレーサビリティ表確認にとどめる
 - 設計書がある場合は補助的に参照してよいが、テストケースの根拠は仕様に置く
 - プロジェクトルートの `CLAUDE.md` でテスト方針・E2Eテスト実行コマンドを確認する
@@ -67,7 +67,7 @@ effort: medium
 | {完了条件1} | {テストケース名} |
 | {完了条件2} | （未カバー → 要追加） |
 
-**機械可読チェック（Issue/PRが対象の場合）**: 上記トレーサビリティ表と同じ内容を `cases` 配列のJSONとしても用意し、`bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-e2e-traceability.sh" <criteria.json> <trace.json>` を実行する。**入出力JSON形式の正本は `scripts/README.md`「extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様」を参照し、ここには複製しない**。**未カバー0件・未知ID0件を返すまで設計を追補する（上限2周）**。2周しても残る場合はループを打ち切り、残存する未カバー条件・未知IDを**返却内容に明記**したうえで次のPhaseに進む（黙って進めない）。このスクリプトが検証するのは「完了条件とテストケースの対応付けの網羅性」であり、テストが完了条件を意味的に満たしているかの検証ではない（意味的妥当性の検証は `/explain-e2e` の責務）。
+**機械可読チェック（Issue/PRが対象の場合）**: 上記トレーサビリティ表と同じ内容を `cases` 配列のJSONとしても用意し、`bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-e2e-traceability.sh" <criteria.json> <trace.json>` を実行する。**入出力JSON形式の正本はプラグイン配下の `scripts/README.md`「extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様」を参照し、ここには複製しない**（所在は上記参照）。**未カバー0件・未知ID0件を返すまで設計を追補する（上限2周）**。2周しても残る場合はループを打ち切り、残存する未カバー条件・未知IDを**返却内容に明記**したうえで次のPhaseに進む（黙って進めない）。このスクリプトが検証するのは「完了条件とテストケースの対応付けの網羅性」であり、テストが完了条件を意味的に満たしているかの検証ではない（意味的妥当性の検証は `/explain-e2e` の責務）。
 
 入力が「機能名」（Issue番号が無い）の場合は Step 1-1 の記載の通りこのスクリプトチェックは適用外であり、目視でのトレーサビリティ表作成のみで代替する。
 


### PR DESCRIPTION
## 概要

`extract-acceptance-criteria.sh` / `check-e2e-traceability.sh` の入出力仕様を `scripts/README.md` に正本として集約し、`skills/create-e2e/SKILL.md` 側は pr-merge と同形式（「正本は scripts/README.md、ここには複製しない」）の参照に置換した。

## 変更内容

- `scripts/README.md`: 末尾に「## extract-acceptance-criteria.sh / check-e2e-traceability.sh の入出力仕様（正本）」セクションを追加。既存の `pr-merge-preflight.sh の出力仕様（正本）` セクションと同形式（表＋挙動の要点）。実仕様は各スクリプトのヘッダコメントと突合済み。
- `skills/create-e2e/SKILL.md`: Step 1-1 / Step 1-3 の仕様（データ形式）記述を README への参照に置換。以下の**行動規律**はインラインのまま残置（README には移動しない）:
  - 未カバー0件・未知ID0件を返すまでの追補（上限2周・打ち切り時は返却内容に明記）
  - 「機能名」ケース（Issue番号なし）はスクリプトチェック自体が適用外
  - `check-e2e-traceability.sh` が `status: no_criteria` を返した場合の目視フォールバック

## 検証

- `shellcheck scripts/extract-acceptance-criteria.sh scripts/check-e2e-traceability.sh` → exit 0、警告なし（スクリプト本体は無変更）
- `scripts/tests/*.sh` 全7ファイル実行 → 全 pass、fail 0（合計438件）
- markdownのみの変更のため lint/typecheck は対象コマンド無しでスキップ（quality-check 結果: pass）

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * `extract-acceptance-criteria` / `check-e2e-traceability` の入出力仕様（正本）として、stdout JSONのフィールド、`parse_status`／`status` の意味、入力方法、stderr出力と終了コード基準を明文化しました。
  * 受け取り側が参照すべきJSONの扱いを更新し、チェックリスト未抽出時の扱いも整理しました。
  * E2Eトレーサビリティ確認用入力JSONの準備方法（`cases`配列）と、未カバー／未知IDが残る場合の次フェーズ移行条件を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->