### PR TITLE
docs(pr-merge): Phase 2 コンフリクト解消手順を references/ に遅延ロード化

### DIFF
--- a/skills/pr-merge/SKILL.md
+++ b/skills/pr-merge/SKILL.md
@@ -75,7 +75,9 @@ base ブランチ判定（承認ゲートの決定）、PR情報・CI・mergeabl
 
 ### Phase 2: コンフリクト解消（必要な場合）
 
-`block_reasons` に `conflicting` を含む場合のみ、`${CLAUDE_PLUGIN_ROOT}/skills/pr-merge/references/conflict-resolution.md` を Read してその手順に従う（相対パス `skills/pr-merge/references/...` では導入先プロジェクトから解決できないため、必ずプラグインルート起点で参照する）。
+`block_reasons` に `conflicting` を含む場合のみ、`${CLAUDE_PLUGIN_ROOT}/skills/pr-merge/references/conflict-resolution.md` を Read してその手順に従う。
+
+> 参照ファイルは導入先プロジェクトではなく**プラグイン配下**にある。Read する際は、スキル起動時にコンテキストへ与えられる「Base directory for this skill」を起点に絶対パスを解決する（例: `<base>/references/conflict-resolution.md`）。Base directory が得られない場合は Bash で `echo "$CLAUDE_PLUGIN_ROOT"` を実行して絶対パスを組み立てる（Read ツールは環境変数を展開しない）。
 
 > **規律フック**: rebase + push 後は preflight の再実行が必須（Phase 0-1 の判定結果は無効になる）。Phase 4 のマージ判断は、この再実行後の値で行うこと（古い値を使い回さない）。再実行後の `.base`/`.gate` が初回値と異なる場合は、値を更新して続行せず**処理を中断して Phase 0-1 からやり直す**。
 

--- a/skills/pr-merge/SKILL.md
+++ b/skills/pr-merge/SKILL.md
@@ -77,7 +77,7 @@ base ブランチ判定（承認ゲートの決定）、PR情報・CI・mergeabl
 
 `block_reasons` に `conflicting` を含む場合のみ、`${CLAUDE_PLUGIN_ROOT}/skills/pr-merge/references/conflict-resolution.md` を Read してその手順に従う（相対パス `skills/pr-merge/references/...` では導入先プロジェクトから解決できないため、必ずプラグインルート起点で参照する）。
 
-> **規律フック**: rebase + push 後は preflight の再実行が必須（Phase 0-1 の判定結果は無効になる）。Phase 4 のマージ判断は、この再実行後の値で行うこと（古い値を使い回さない）。
+> **規律フック**: rebase + push 後は preflight の再実行が必須（Phase 0-1 の判定結果は無効になる）。Phase 4 のマージ判断は、この再実行後の値で行うこと（古い値を使い回さない）。再実行後の `.base`/`.gate` が初回値と異なる場合は、値を更新して続行せず**処理を中断して Phase 0-1 からやり直す**。
 
 ### Phase 3: コードレビュー
 

--- a/skills/pr-merge/SKILL.md
+++ b/skills/pr-merge/SKILL.md
@@ -75,39 +75,9 @@ base ブランチ判定（承認ゲートの決定）、PR情報・CI・mergeabl
 
 ### Phase 2: コンフリクト解消（必要な場合）
 
-`block_reasons` に `conflicting` が含まれる場合（`mergeable` が `CONFLICTING`）：
+`block_reasons` に `conflicting` を含む場合のみ、`${CLAUDE_PLUGIN_ROOT}/skills/pr-merge/references/conflict-resolution.md` を Read してその手順に従う（相対パス `skills/pr-merge/references/...` では導入先プロジェクトから解決できないため、必ずプラグインルート起点で参照する）。
 
-1. **PRのブランチをローカルに取得**
-   ```bash
-   git fetch origin
-   gh pr checkout "$PR_NUM"
-   ```
-
-2. **PR の base（Phase 0-1 で取得済みの `$BASE`）の最新を取り込んでコンフリクト解消**
-
-   統合ブランチ方式では PR の base が `main` とは限らないため、**Phase 0-1 で取得した `$BASE`** を対象に rebase する（`main` 固定にせず、再取得もしない）:
-   ```bash
-   git fetch origin "$BASE"
-   git rebase "origin/$BASE"
-   ```
-   - コンフリクトが発生したファイルを確認
-   - 各ファイルのコンフリクトを手動で解消
-   - 解消後: `git add <ファイル> && git rebase --continue`
-
-3. **解消結果をプッシュ**
-   ```bash
-   git push --force-with-lease
-   ```
-
-4. **CI再確認・preflightの再実行**
-
-   rebase + push で PR の状態（CI・`mergeable`・レビュー）が変わるため、**Phase 0-1 の判定結果はここで無効になる**。CI完了を待った上で preflight を再実行し、値を取り直す（`$GATE`/`$BASE` はブランチ構成由来のため不変）:
-   ```bash
-   gh pr checks "$PR_NUM" --watch
-   PREFLIGHT=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/pr-merge-preflight.sh" "$PR_NUM")
-   BLOCKING=$(jq -r '.blocking' <<<"$PREFLIGHT")
-   ```
-   Phase 4 のマージ実行は、この再実行後の値で判断する（Phase 2 に入る前の古い値を使い回さない）。
+> **規律フック**: rebase + push 後は preflight の再実行が必須（Phase 0-1 の判定結果は無効になる）。Phase 4 のマージ判断は、この再実行後の値で行うこと（古い値を使い回さない）。
 
 ### Phase 3: コードレビュー
 

--- a/skills/pr-merge/references/conflict-resolution.md
+++ b/skills/pr-merge/references/conflict-resolution.md
@@ -1,0 +1,37 @@
+# Phase 2: コンフリクト解消（必要な場合）
+
+> **前提**: `$BASE`（PR の base ブランチ）・`$GATE`（承認ゲート種別）・`$PR_NUM`（PR番号）は SKILL.md の Phase 0-1 で定義済みである。このファイルではそれらを再取得せずそのまま再利用する。
+
+`block_reasons` に `conflicting` が含まれる場合（`mergeable` が `CONFLICTING`）：
+
+1. **PRのブランチをローカルに取得**
+   ```bash
+   git fetch origin
+   gh pr checkout "$PR_NUM"
+   ```
+
+2. **PR の base（Phase 0-1 で取得済みの `$BASE`）の最新を取り込んでコンフリクト解消**
+
+   統合ブランチ方式では PR の base が `main` とは限らないため、**Phase 0-1 で取得した `$BASE`** を対象に rebase する（`main` 固定にせず、再取得もしない）:
+   ```bash
+   git fetch origin "$BASE"
+   git rebase "origin/$BASE"
+   ```
+   - コンフリクトが発生したファイルを確認
+   - 各ファイルのコンフリクトを手動で解消
+   - 解消後: `git add <ファイル> && git rebase --continue`
+
+3. **解消結果をプッシュ**
+   ```bash
+   git push --force-with-lease
+   ```
+
+4. **CI再確認・preflightの再実行**
+
+   rebase + push で PR の状態（CI・`mergeable`・レビュー）が変わるため、**Phase 0-1 の判定結果はここで無効になる**。CI完了を待った上で preflight を再実行し、値を取り直す（`$GATE`/`$BASE` はブランチ構成由来のため不変）:
+   ```bash
+   gh pr checks "$PR_NUM" --watch
+   PREFLIGHT=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/pr-merge-preflight.sh" "$PR_NUM")
+   BLOCKING=$(jq -r '.blocking' <<<"$PREFLIGHT")
+   ```
+   Phase 4 のマージ実行は、この再実行後の値で判断する（Phase 2 に入る前の古い値を使い回さない）。

--- a/skills/pr-merge/references/conflict-resolution.md
+++ b/skills/pr-merge/references/conflict-resolution.md
@@ -35,3 +35,5 @@
    BLOCKING=$(jq -r '.blocking' <<<"$PREFLIGHT")
    ```
    Phase 4 のマージ実行は、この再実行後の値で判断する（Phase 2 に入る前の古い値を使い回さない）。
+
+   `.base` / `.gate` も再取得し、初回値（Phase 0-1 で取得した `$BASE`/`$GATE`）と異なる場合は、値を黙って更新せず**処理を中断して Phase 0-1 からやり直す**（base retarget は稀な操作であり、途中の rebase 前提が崩れているため）。


### PR DESCRIPTION
## 概要

`skills/pr-merge/SKILL.md` の「Phase 2: コンフリクト解消（必要な場合）」（35行）を `skills/pr-merge/references/conflict-resolution.md` へ遅延ロード化。コンフリクト無し時（大多数の起動）のコンテキスト消費を約30行削減する。

## 変更内容

- `skills/pr-merge/references/conflict-resolution.md` を新規作成し、Phase 2 本文を**内容変更なしの純移動**で移設（byte-identical を確認済み）
- 冒頭に `$BASE`/`$GATE`/`$PR_NUM` が SKILL.md の Phase 0-1 で定義済みである前提を明記
- SKILL.md 側の Phase 2 セクションは「`block_reasons` に `conflicting` を含む場合のみ `${CLAUDE_PLUGIN_ROOT}/skills/pr-merge/references/conflict-resolution.md` を Read してその手順に従う」という2行に短縮
- **「rebase + push 後は preflight 再実行必須・Phase 4 は再実行後の値で判断」の規律フックは、正しさに直結するため references 全文に加えて SKILL.md 側にも1行残置**

## 検証

- `git diff` で SKILL.md から削除した Phase 2 本文と references/conflict-resolution.md の内容を突き合わせ、コードブロックのインデント・変数名・コメントも含め一字一句一致することを確認（サブエージェントによる独立検証も実施）
- markdown のみの変更のため quality-check は lint/typecheck/test すべて該当コマンドなしで skip（妥当）
- self-review（code-reviewer / design-reviewer）で「純移動であること」「規律フックの視認性」「パス規約の一貫性」を確認済み。軽微な改善提案（見出し文言・発火条件の3箇所重複）はあるが、issue 要件を満たしているため未修正

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - コンフリクト発生時（block_reasons に conflicting を含む）の解消手順（Phase 2）を追加し、解消→再プッシュ→CI完了待ち→事前チェック再実行の流れを整理しました。  
  - Phase 4 のマージ判断は再実行後の最新結果に基づくと明記しました。  
  - 再取得した `.base` / `.gate` が初回と異なる場合はやり直すための中断分岐を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->