### PR TITLE
fix(test): 検査(vii)の言い換え検出と正本一覧追記（#103 の後着レビュー対応）

### DIFF
--- a/docs/plugin-path-conventions.md
+++ b/docs/plugin-path-conventions.md
@@ -145,5 +145,7 @@ Dynamic Workflow スクリプトが `agent(prompt, { schema, ... })` に渡す J
 - 成立しない `echo "$CLAUDE_PLUGIN_ROOT"` 解決手順の再出現
 - `skills/*/scripts/*.js` の `agentType: '...'` および `agents/*.md` の自己記述が `claude-harness:` プレフィックス付きであること（(g) の規約）
 - `skills/*/scripts/*.js` に、引用符に直接続くハードコードされた `scripts/` 相対パス文字列リテラルが無いこと
+- `skills/*/scripts/*.js`（Workflow スクリプト）の `export` 宣言が `export const meta` の1件のみであること（前掲の Workflow ランタイム契約）
+- 「実行時に（プラグインルートへ）展開される」等、`${CLAUDE_PLUGIN_ROOT}` が環境変数として自動展開されるかのような誤説明の再出現が無いこと（正: 表記上のプレースホルダであり、実行前に Base directory から解決した絶対パスへ置換する）
 
 既知の許容パターンはテストファイル内でホワイトリストとして管理する。

--- a/scripts/tests/test-path-conventions.sh
+++ b/scripts/tests/test-path-conventions.sh
@@ -354,8 +354,14 @@ fi
 echo ""
 echo "=== (vii) 誤った「実行時に展開」説明の再出現チェック ==="
 
-misexp_pattern='実行時にプラグインルートへ展開'
-misexp_hits="$(grep -rn "$misexp_pattern" skills agents docs --include='*.md')"
+# 「実行時に…展開」「自動的に…展開」「環境変数として展開」等の言い換えも検出する。
+# 正しい説明（「実行前に…絶対パスに置換」「絶対パスへ展開したうえで」= モデル自身が行う指示）は
+# 「実行時に/自動」を含まないためマッチしない。
+misexp_pattern='(実行時に[^。]*展開|自動的に[^。]*展開|自動で[^。]*展開|環境変数として[^。]*展開)'
+# 対象は実行時にモデルへロードされる skills/ agents/ のみ。docs/（特に規約正本
+# docs/plugin-path-conventions.md）は誤説明の引用・「hooks 設定内でのみ展開される」という
+# 正当な説明を必然的に含むため対象外（実行時ファイルからの docs/ 参照は検査(ii)で禁止済み）。
+misexp_hits="$(grep -rnE "$misexp_pattern" skills agents --include='*.md')"
 misexp_exit=$?
 
 if [ "$misexp_exit" -ge 2 ]; then


### PR DESCRIPTION
マージ後に着弾した PR #103 の CodeRabbit 指摘2件への対応。

1. **正本一覧への追記**: docs の再発防止テスト一覧に検査 (iv)(vii) 相当を追記
2. **言い換え検出**: パターンを選言化（実行時に/自動的に/自動で/環境変数として…展開）。あわせて grep の -E 欠落（選言がリテラル扱いで全 MISS になる実バグ）を検出・修正し、対象を skills/ agents/ に限定（docs 正本は引用・正当説明を含むため）

言い換え3種の合成違反で検出確認済み・全28スイート回帰なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WckT2LbiAUPo2tE4WnEzkN