### PR TITLE
refactor(agents/skills): frontmatter descriptionから呼び出し経路・Issue経緯を削除

### DIFF
--- a/agents/attestation-verifier.md
+++ b/agents/attestation-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: attestation-verifier
-description: "クロスリポジトリ依存確証テーブルの1行（仮定・確証結果・根拠 owner/repo@SHA/path:line）に対し独立に反証を試みる懐疑者エージェント。skills/cross-repo-verify/SKILL.md の「確証の独立再照合」節から、Task ツールで `subagent_type: 'claude-harness:attestation-verifier'` として行ごとに呼び出される（テーブルが複数行なら並列 spawn される）。確証した本人（呼び出し元）が既に取得した内容や要約を信用せず、自分で `gh api` により対象ファイルを独立に再取得して判定する。"
+description: クロスリポジトリ依存の確証結果（仮定・根拠）を鵜呑みにせず、依存先の実コードを独立に再取得して反証を試みる懐疑者エージェント。
 # tools: 検証専用エージェントのため読み取り系のみ。ただし独立取得に gh api（Bash 経由）が必須。
 tools: Bash, Read, Grep
 model: sonnet

--- a/agents/claim-advocate.md
+++ b/agents/claim-advocate.md
@@ -1,6 +1,6 @@
 ---
 name: claim-advocate
-description: "却下判断（rejected/scope_expansion に分類されたPRレビューコメント）への懐疑者として使用。skills/pr-review-respond/SKILL.md（Step 4）から `subagent_type: 'claude-harness:claim-advocate'` として、Task ツールで却下系に分類された項目1件ごとに単体で呼び出される（3体多数決ではない。複数件ある場合は呼び出し元が1メッセージにまとめて並列 spawn することがある）。"
+description: PRレビューコメントへの却下判断（対応不要と分類された指摘）に対し、その判断自体を疑い元の指摘の正当性を探す懐疑者エージェント。
 # tools: 検証専用エージェントのため読み取り系のみ。コード修正は行わない。
 tools: Read, Glob, Grep
 model: sonnet

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: "ソースコードをレビューする際に使用。「コードをレビューして」「実装をチェックして」「PRをレビューして」といったレビュー依頼時に自動委譲される。`/self-review`（skills/self-review/SKILL.md）から Task ツールで `subagent_type: 'claude-harness:code-reviewer'` として、design-reviewer とバリア付き並列で呼び出される経路もある（Issue #44・#107）。`/pr-merge`（skills/pr-merge/SKILL.md）の分岐B（統合ブランチゲート・リスクゲート非該当時の単発委譲）・分岐C（統合ブランチゲート・リスクゲート該当時の3レンズ judge panel、Task並列 spawn）の両方からも Task ツール経由で呼び出される（Issue #109）。"
+description: ソースコードをレビューする際に使用するエージェント。「コードをレビューして」「実装をチェックして」「PRをレビューして」といったレビュー依頼時に自動委譲される。
 # tools: レビュー専用エージェントのため、コード編集ツール（Edit, Write）は意図的に除外。
 # 修正が必要な場合は、レビュー結果を報告し、実装エージェント（feature-implementer）に委譲する。
 # 品質チェックコマンドの実行もこのエージェントの責務ではない（Fixステージ後段に一本化。Issue #44）。

--- a/agents/debt-scanner.md
+++ b/agents/debt-scanner.md
@@ -1,6 +1,6 @@
 ---
 name: debt-scanner
-description: "プロジェクトの担当ディレクトリ配下を技術負債の観点でスキャンする際に使用。skills/reduce-debt/SKILL.md（Step 2-3）から `subagent_type: 'claude-harness:debt-scanner'` として、Task ツールでスキャンバケットごとに並列 spawn される。"
+description: プロジェクトの担当ディレクトリ配下を技術負債の観点でスキャンする際に使用するエージェント。
 # tools: スキャン専用エージェントのため読み取り系のみ。コード修正は行わない。
 tools: Read, Glob, Grep
 model: sonnet

--- a/agents/debt-verifier.md
+++ b/agents/debt-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: debt-verifier
-description: "debt-scanner が検出した技術負債の指摘に対して懐疑的に反証を試みる際に使用。skills/reduce-debt/SKILL.md（Step 2-4）から `subagent_type: 'claude-harness:debt-verifier'` として、Task ツールで検証バッチごとに3体並列 spawn され、多数決の一角を担う。"
+description: debt-scanner が検出した技術負債の指摘に対して懐疑的に反証を試みる際に使用するエージェント。ファイル起点でCLAUDE.mdの規約と照合する点で、diff起点で反証する finding-verifier とは反証観点が異なる。
 # tools: 検証専用エージェントのため読み取り系のみ。コード修正は行わない。
 tools: Read, Glob, Grep
 model: sonnet

--- a/agents/decompose-judge.md
+++ b/agents/decompose-judge.md
@@ -1,6 +1,6 @@
 ---
 name: decompose-judge
-description: "ticket-decomposer が生成した3案の実装タスク分解案を採点・合成する際に使用。skills/create-ticket/references/decompose-mode.md から Task ツールで `subagent_type: 'claude-harness:decompose-judge'` として呼び出され、受入基準の網羅・依存グラフの妥当性に不備があれば上限付きで再実行される（Issue #46・#112）。"
+description: ticket-decomposer が生成した複数の実装タスク分解案を採点し、最良の要素を合成した最終分解計画を作成する際に使用するエージェント。
 # tools: 判断材料（3候補案・計算済みグラフ指標・網羅結果）はすべてプロンプトに注入されるため、
 # 探索系ツール（Glob/Grep）は不要と判断し持たせない。ticket-decomposer と異なり、あなた自身が
 # files フィールドを新規に創作することもない（候補案の合成に専念する）。Read のみ、候補案の

--- a/agents/design-deviation-verifier.md
+++ b/agents/design-deviation-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: design-deviation-verifier
-description: "feature-implementer が Phase 2-3 で自己申告した『クリティカル設計整合』（✅表明）に対して独立に反証を試みる際に使用する。feature-implementer から Phase 5（5-1/5-2 の判定確定後の 5-3）で、Task ツール経由で `subagent_type: 'claude-harness:design-deviation-verifier'` として直接 spawn される（Dynamic Workflow を介さない直接呼び出し）。既定1体で判定し、violation（決定への違反）と判定した場合のみ追加2体（計3体）で多数決する。反証対象は『実装は機能仕様のクリティカル設計決定に従っている』という自己申告であり、finding-verifier（レビュー指摘の偽陽性除去。逆方向）とは異なり、見逃されている違反の発見（偽陰性の是正）を目指す。"
+description: feature-implementer が自己申告した「クリティカル設計整合」に対し、実装が親要件チケットの決定に本当に従っているかを独立に反証する際に使用するエージェント。
 # tools: 検証専用エージェントのため読み取り系のみ。コード修正は行わない。
 tools: Read, Glob, Grep
 model: sonnet

--- a/agents/design-reviewer.md
+++ b/agents/design-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: design-reviewer
-description: "設計レビューを行う際に使用。「設計をレビューして」「アーキテクチャを確認して」「依存関係をチェックして」といった設計レビュー依頼時に自動委譲される。`/self-review`（skills/self-review/SKILL.md）から Task ツールで `subagent_type: 'claude-harness:design-reviewer'` として、code-reviewer とバリア付き並列で呼び出される経路もある（Issue #44・#107）。"
+description: 設計レビューを行う際に使用するエージェント。「設計をレビューして」「アーキテクチャを確認して」「依存関係をチェックして」といった設計レビュー依頼時に自動委譲される。
 # tools: レビュー専用エージェントのため、コード編集ツール（Edit, Write）は意図的に除外。
 # 修正が必要な場合は、レビュー結果を報告し、実装エージェント（feature-implementer）に委譲する。
 tools: Read, Glob, Grep, Bash

--- a/agents/doc-verifier.md
+++ b/agents/doc-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: doc-verifier
-description: "実装とドキュメント（要件定義・設計書）の整合性を確認する際に使用。「ドキュメントと整合性を確認して」「設計書と実装が合っているか確認して」といった依頼時に自動委譲される。`/promote-verify`（skills/promote-verify/SKILL.md）からも、受入基準1件ごとに Task ツールで `subagent_type: 'claude-harness:doc-verifier'` として fan-out 起動される（Issue #110。Dynamic Workflow ではなく直接委譲）。"
+description: 実装とドキュメント（要件定義・設計書）の整合性を確認する際に使用するエージェント。「ドキュメントと整合性を確認して」「設計書と実装が合っているか確認して」といった依頼時に自動委譲される。
 tools: Read, Glob, Grep
 model: sonnet
 # effort: 整合性チェックが中心のため medium。

--- a/agents/e2e-explanation-verifier.md
+++ b/agents/e2e-explanation-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-explanation-verifier
-description: "explain-e2e の Phase 2（独立検証）が、Phase 1 の解説とE2E実装コードの整合・アサーションの妥当性を新鮮なコンテキストで確認する際に使用する。`skills/explain-e2e/SKILL.md` Phase 2 の Verify 段階から、Task ツールで `subagent_type: 'claude-harness:e2e-explanation-verifier'` として、テストファイルごとに1メッセージで並列 fan-out 起動される（Issue #47・#114）。解説を書いた本人（Phase 1・メインセッション）と同一コンテキストにならないことが独立検証の前提であり、このエージェントは Phase 1 の対話・解説内容を一切知らない新規セッションとして起動される。"
+description: 実装済みE2Eテストの解説とコードの整合・アサーションの妥当性を、解説作成者とは独立したコンテキストで確認する際に使用するエージェント。
 # tools: 読み取り専用の検証専用エージェントのため。コード修正は行わない。
 tools: Read, Grep
 model: sonnet

--- a/agents/e2e-mutation-injector.md
+++ b/agents/e2e-mutation-injector.md
@@ -1,6 +1,6 @@
 ---
 name: e2e-mutation-injector
-description: "explain-e2e の Phase 2（独立検証）Mutation ステージが、重要フローのE2Eテストに対して意味のある不具合を1箇所注入する際に使用する。`skills/explain-e2e/SKILL.md` Phase 2 の Mutation 段階から、Task ツールで `subagent_type: 'claude-harness:e2e-mutation-injector'` として、対象テストごとに逐次（並列にしない）起動される（Issue #47・#114）。注入以外の全手順（テスト実行・失敗判定・`git checkout --` による復元・復元確認・再実行パス確認）は `scripts/mutation-run.sh` に決定化されており、このエージェントの責務は「意味のある変異点を選んで Edit する」ことだけに縮小されている。"
+description: E2Eテストが実際に不具合を検出できるかを確認するため、重要フローの実装コードに意図的な不具合を1箇所だけ注入する際に使用するエージェント。注入後の復元は呼び出し元が担う前提のため、復元手順を持つフローからのみ使用すること。
 # tools: 変異点の特定（Read/Grep/Glob）とEditのみ。テスト実行・復元・コミット等の
 # 決定的な手順は呼び出し元（/explain-e2e の SKILL.md Phase 2）が mutation-run.sh を
 # 直接Bash実行することで担うため、このエージェント自身にBashは持たせない（Issue #47・#114）。

--- a/agents/finding-verifier.md
+++ b/agents/finding-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: finding-verifier
-description: "code-reviewer/design-reviewer が報告したレビュー指摘（severity: high かつレビュアー自身の verdict が PLAUSIBLE のもの）に対して懐疑的に反証を試みる際に使用。`/self-review`（skills/self-review/SKILL.md）から Task ツールで `subagent_type: 'claude-harness:finding-verifier'` として3体並列 spawn され、多数決の一角を担う（Issue #44・#107）。`/pr-merge`（skills/pr-merge/SKILL.md）の分岐C（judge panel の any-veto成立時）からは Task ツールで blocker1件ごとに1体だけ呼ばれる単一懐疑者設計で使われる（Issue #109）。`/promote-verify`（skills/promote-verify/SKILL.md）からも同じ単一懐疑者設計で、Task ツールにより受入基準1件ごとに1体だけ呼び出される（Issue #110）。diff起点のレビュー指摘/blocker型の懐疑者として、ファイル起点・CLAUDE.md照合型の `debt-verifier` とは反証観点が異なる。"
+description: code-reviewer/design-reviewer が報告したレビュー指摘に対して懐疑的に反証を試みる際に使用するエージェント。diff起点でレビュー指摘・blockerを検証する点で、ファイル起点・CLAUDE.md照合型の debt-verifier とは反証観点が異なる。
 # tools: 検証専用エージェントのため読み取り系のみ。コード修正は行わない。
 tools: Read, Glob, Grep
 model: sonnet

--- a/agents/issue-conflict-predictor.md
+++ b/agents/issue-conflict-predictor.md
@@ -1,6 +1,6 @@
 ---
 name: issue-conflict-predictor
-description: "para-impl の複数Issue並列実装で、Issue間のファイル衝突・依存関係を予測する際に使用する。リード（/para-impl の star 型並列実装）から Task ツール経由で `subagent_type: 'claude-harness:issue-conflict-predictor'` として、Issue数が閾値（既定5件）以上の場合のみ、全Issueに対して並列fan-outで呼び出される（Issue #45・#105）。予測結果はリード側で交差判定（予測ファイル集合の突き合わせ）されるが、判定結果は自動直列化トリガーではなくリードの直列化判断への**ヒント**に格下げされる——偽陰性・偽陽性を含みうる予測に基づいて機械的に直列化すると、統合時の衝突検知・解決という既存の安全網（リードの役目）を弱めてしまうため。"
+description: 複数Issueの並列実装で、Issue間のファイル衝突・依存関係を予測する際に使用するエージェント。予測結果は並列実装リードの直列化判断のヒントとして使われる。
 tools: Read, Glob, Grep
 model: sonnet
 # effort: 1Issueあたりの予測に限定した軽量タスクのため low。

--- a/agents/pr-comment-classifier.md
+++ b/agents/pr-comment-classifier.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comment-classifier
-description: "PRレビューコメント1件を分類する際に使用。skills/pr-review-respond/SKILL.md（Step 3）から `subagent_type: 'claude-harness:pr-comment-classifier'` として、Task ツールで1コメント=1回呼び出される（複数コメントがある場合は呼び出し元が1メッセージにまとめて並列 spawn する）。"
+description: PRレビューコメント1件の対応方針を分類する際に使用するエージェント。
 # tools: 分類専用エージェントのためコード修正は行わない。diff_hunkだけでは
 # 「対応済みか」「スコープ拡大か」を判断できない場合に、対象ファイルの現状を確認できるよう
 # 読み取り系のみ付与する。

--- a/agents/spec-critic.md
+++ b/agents/spec-critic.md
@@ -1,6 +1,6 @@
 ---
 name: spec-critic
-description: "機能仕様ドキュメント（docs/features/{slug}.md）を3レンズ（受入基準の検証可能性/内部整合/下流実装可能性）のいずれかの観点で批評する際に使用。`/define-feature`（skills/define-feature/SKILL.md）Step 6.5-2 から Task ツールで `subagent_type: 'claude-harness:spec-critic'` として、focus値を変えて3体・1メッセージで並列起動される（Issue #111）。"
+description: 機能仕様ドキュメントを受入基準の検証可能性・内部整合・下流実装可能性のいずれかの観点で批評する際に使用するエージェント。
 tools: Read, Grep
 model: sonnet
 # effort: メイン（define-feature=opus/xhigh）より軽量にしてトークン単価を抑える。批評は

--- a/agents/spec-fixer.md
+++ b/agents/spec-fixer.md
@@ -1,6 +1,6 @@
 ---
 name: spec-fixer
-description: "機能仕様ドキュメント（docs/features/{slug}.md）の blocker 指摘を機械的に修正する際に使用。`/define-feature`（skills/define-feature/SKILL.md）Step 6.5-3 から Task ツールで `subagent_type: 'claude-harness:spec-fixer'` として、Fix フェーズでスコープ付きに1体呼び出される（Issue #111）。"
+description: 機能仕様ドキュメントの blocker 指摘を機械的に修正する際に使用するエージェント。
 # tools: 既存ファイルの部分編集のみのためWrite不要。
 tools: Read, Edit, Grep
 model: sonnet

--- a/agents/ticket-decomposer.md
+++ b/agents/ticket-decomposer.md
@@ -1,6 +1,6 @@
 ---
 name: ticket-decomposer
-description: "親要件チケットを実装タスクへ分解する際に使用。skills/create-ticket/references/decompose-mode.md から Task ツールで `subagent_type: 'claude-harness:ticket-decomposer'` として、異なるレンズ（依存最小優先／垂直スライス優先／レイヤ分割優先）を与えられた3体が1メッセージで並列 spawn される（Issue #46・#112）。"
+description: 親要件チケットの実装タスクへの分解案を生成する際に使用するエージェント。
 # tools: 分解案生成専用エージェントのため読み取り系のみ。コード修正・Issue作成は行わない。
 # 注入されたcodebaseAnalysisリストに加え、filesフィールドの幻覚防止のため自己に
 # Glob/Grepでの存在確認を許可する。

--- a/agents/ticket-worker.md
+++ b/agents/ticket-worker.md
@@ -1,6 +1,6 @@
 ---
 name: ticket-worker
-description: para-impl の複数Issue並列実装（star 型 orchestrator-worker）で、1チケット分の実装フローを worktree 内で実行する worker。リードから Issue・worktree・ブランチ・フロー手順を受け取って自走する。
+description: 複数Issueの並列実装で、1つのIssueをworktree内で最初から最後まで実装するworkerエージェント。リードから割り当てられたIssueを自走で実装する際に使用する。
 tools: Read, Glob, Grep, Edit, Write, Bash, Task, Skill
 model: sonnet
 # effort: CI失敗の分析と Phase 4-5 差し戻し判断を含むフロー統括のため high（実装の中核は feature-implementer 側が担う）。

--- a/skills/para-impl/SKILL.md
+++ b/skills/para-impl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: para-impl
-description: "GitHub Issueを分析し、設計→TDD実装(エージェント内でQC通過まで)→コミット→E2E→PR→CI確認の1チケットフローを実装フェーズの人間ゲートなしで実行する。クリティカル設計は要件チケット側で決定済み前提。複数Issue時は star 型（orchestrator-worker）で ticket-worker に並列委譲する。Triggers on: '/para-impl', '並列実装', 'Issueを実装して'"
+description: "GitHub Issueを分析し、設計→TDD実装(エージェント内でQC通過まで)→コミット→E2E→PR→CI確認の1チケットフローを実装フェーズの人間ゲートなしで実行する。Triggers on: '/para-impl', '並列実装', 'Issueを実装して'"
 argument-hint: "<Issue番号> [Issue番号...] [--base <統合ブランチ>]"
 model: opus
 # effort: 設計〜TDD実装〜PRの自走フローを担うため high。


### PR DESCRIPTION
## Summary
- `agents/*.md`（20本中18本）と `skills/para-impl/SKILL.md` の frontmatter `description` を「何をするエージェントか＋いつ使うか」の1〜2文に圧縮
- 呼び出し経路（どのスキルの何Stepから何体spawnされるか）・Issue番号・設計経緯を削除。正本は各呼び出し元 SKILL.md
- `finding-verifier`・`debt-verifier` は自動委譲の判別に有用な相互識別文（反証観点の違い）のみ1文残した
- `agents/*.md` description合計: **10,533B → 4,499B**（約57%削減）。毎セッションの常時ロード分を削減
- `e2e-engineer.md`・`feature-implementer.md` は既に基準を満たしており変更なし
- `skills/*/SKILL.md` は para-impl 以外の16本を確認したが、既に「目的1文＋Triggers on」で簡潔だったため変更なし（explain-e2e・promote-verify含む）
- `description` フィールド以外（本文・他frontmatterフィールド）は一切変更していない（`doc-verifier.md`・`design-deviation-verifier.md`・`finding-verifier.md` も description 行のみ変更、`git diff --stat` で各1行変更のみを確認済み）

## Test plan
- [x] 全37frontmatterブロックがYAMLとして妥当（`YAML.load_file` で検証）
- [x] `/quality-check`: `scripts/tests/*.sh` 全20ファイルpass（合計970件超のアサーション、失敗0）
- [x] `scripts/tests/test-path-conventions.sh` 7サブチェック全pass（`claude-harness:` prefix整合等のパス規約回帰なし）
- [x] `/self-review`: 3ラウンドで収束（`converged: true`）。code-reviewer/design-reviewerによる初回レビューで11件の低〜中重大度の指摘、4件修正、最終ラウンドで指摘ゼロを確認

Closes #125