### PR TITLE
refactor(scripts): 共通ヘルパーをlib/common.shへ集約

### DIFF
--- a/scripts/analyze-project.sh
+++ b/scripts/analyze-project.sh
@@ -34,18 +34,25 @@
 
 set -u
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
+}
+
+# analyze-project.sh の check_jq エラーJSONは他スクリプトと異なり status フィールドを含む
+# （元実装の出力仕様を維持するため）。呼び出し箇所ごとに引数を渡し忘れるリスクを無くすため、
+# lib/common.sh の check_jq をこのスクリプト専用のエラーJSONへ束縛したローカル版で上書きする
+# （lib/common.sh の _common_check_jq_impl を直接呼ぶ）。以降このファイル内の check_jq 呼び出しは
+# 引数無しで統一する。
+ANALYZE_PROJECT_JQ_ERROR_JSON='{"status":"error","error":"jq not found"}'
+check_jq() {
+  _common_check_jq_impl "$ANALYZE_PROJECT_JQ_ERROR_JSON"
+}
+
 # ------------------------------------------------------------------
 # 共通ヘルパー
 # ------------------------------------------------------------------
-
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"status":"error","error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
-}
 
 # 空白区切りリスト $2.. の中に要素 $1 が含まれるか
 _contains_word() {
@@ -488,6 +495,44 @@ fetch_test_prereqs() {
 }
 
 # ------------------------------------------------------------------
+# 共通: 走査から除外するディレクトリ名（find -prune 節の一本化。Issue #128）
+# ------------------------------------------------------------------
+
+# fetch_dir_tree / fetch_docs_evidence / fetch_named_dirs / fetch_colocated_tests / fetch_axes
+# が共通して除外するディレクトリ「名」の一覧の単一の正本。除外を1つ追加/削除する場合は
+# ここだけを直せばよい。ただし元実装では2種類の異なるマッチ深さの prune 節が使われていた
+# （fetch_dir_tree のみ任意の深さ、他4関数はトップレベルのみ）ため、この一覧から実際に
+# find 引数配列を組み立てる際は用途に応じて build_analyze_project_prune_name_args
+# （任意深さ）/ build_analyze_project_prune_path_args（トップレベルのみ）を使い分ける
+# （下記コメント参照。挙動変更ゼロの原則によりこの差は統一しない）。
+ANALYZE_PROJECT_EXCLUDE_DIR_NAMES=(.git node_modules dist .next target __pycache__ .venv vendor)
+
+# -name 形式のprune用find引数配列を構築し、グローバル配列 ANALYZE_PROJECT_PRUNE_NAME_ARGS に
+# 格納する（basenameの一致なので任意の深さで除外される。元実装の fetch_dir_tree の挙動）。
+# fetch_dir_tree が呼び出し時に都度呼ぶ。
+build_analyze_project_prune_name_args() {
+  ANALYZE_PROJECT_PRUNE_NAME_ARGS=()
+  local name
+  for name in "${ANALYZE_PROJECT_EXCLUDE_DIR_NAMES[@]}"; do
+    [ ${#ANALYZE_PROJECT_PRUNE_NAME_ARGS[@]} -gt 0 ] && ANALYZE_PROJECT_PRUNE_NAME_ARGS+=(-o)
+    ANALYZE_PROJECT_PRUNE_NAME_ARGS+=(-name "$name")
+  done
+}
+
+# -path "./name" 形式のprune用find引数配列を構築し、グローバル配列
+# ANALYZE_PROJECT_PRUNE_PATH_ARGS に格納する（find のパスは "./" 始まりのため cwd直下の
+# パスにのみ一致=トップレベルのみ除外。元実装の他4関数の挙動をそのまま維持する）。
+# fetch_docs_evidence / fetch_named_dirs / fetch_colocated_tests / fetch_axes が呼び出し時に都度呼ぶ。
+build_analyze_project_prune_path_args() {
+  ANALYZE_PROJECT_PRUNE_PATH_ARGS=()
+  local name
+  for name in "${ANALYZE_PROJECT_EXCLUDE_DIR_NAMES[@]}"; do
+    [ ${#ANALYZE_PROJECT_PRUNE_PATH_ARGS[@]} -gt 0 ] && ANALYZE_PROJECT_PRUNE_PATH_ARGS+=(-o)
+    ANALYZE_PROJECT_PRUNE_PATH_ARGS+=(-path "./${name}")
+  done
+}
+
+# ------------------------------------------------------------------
 # 2d. ディレクトリ構成のスキャン
 # ------------------------------------------------------------------
 
@@ -496,11 +541,11 @@ fetch_dir_tree() {
   local max_depth="${2:-3}"
   local max_entries="${3:-200}"
   local all_entries
+  build_analyze_project_prune_name_args
   # 除外ディレクトリは走査前に -prune で刈り込む（grep で事後除外すると大規模プロジェクトで
   # node_modules 等を全走査してメモリに積むことになり、解析時間・メモリ使用量が急増するため）
   all_entries=$(cd "$dir" 2>/dev/null && find . -mindepth 1 -maxdepth "$max_depth" \
-    \( -type d \( -name .git -o -name node_modules -o -name dist -o -name .next \
-       -o -name target -o -name __pycache__ -o -name .venv -o -name vendor \) \) -prune \
+    \( -type d \( "${ANALYZE_PROJECT_PRUNE_NAME_ARGS[@]}" \) \) -prune \
     -o \( -type d -o -type f \) -print 2>/dev/null \
     | sed 's|^\./||' \
     | sort)
@@ -536,23 +581,33 @@ DESIGN_DOC_PATTERNS=(
 # ディレクトリ（src/domain 等）を誤って含めないよう -type f + 拡張子で限定する。
 DESIGN_DOC_EXTENSIONS_REGEX='\.(md|mdx|txt|rst|adoc|yaml|yml|json|png|svg|drawio|excalidraw|puml|sql)$'
 
+# DESIGN_DOC_PATTERNS の各パターンを -iname -o で連結したfind引数配列を構築し、
+# グローバル配列 ANALYZE_PROJECT_INAME_OR_ARGS に格納する（パターン数ぶんフルツリー走査
+# していたのを1回の find に統合するため。Issue #128）。
+build_analyze_project_iname_or_args() {
+  ANALYZE_PROJECT_INAME_OR_ARGS=()
+  local pattern
+  for pattern in "$@"; do
+    [ ${#ANALYZE_PROJECT_INAME_OR_ARGS[@]} -gt 0 ] && ANALYZE_PROJECT_INAME_OR_ARGS+=(-o)
+    ANALYZE_PROJECT_INAME_OR_ARGS+=(-iname "$pattern")
+  done
+}
+
 fetch_docs_evidence() {
   local dir="$1"
   local docs_dir="null"
   [ -d "$dir/docs" ] && docs_dir='"docs"'
 
   local -a results=()
-  local pattern
-  for pattern in "${DESIGN_DOC_PATTERNS[@]}"; do
-    while IFS= read -r f; do
-      [ -n "$f" ] && results+=("$f")
-    done < <(cd "$dir" 2>/dev/null && find . \
-      \( -path "./.git" -o -path "./node_modules" -o -path "./dist" -o -path "./.next" \
-         -o -path "./target" -o -path "./__pycache__" -o -path "./.venv" -o -path "./vendor" \) -prune \
-      -o -type f -iname "$pattern" -print 2>/dev/null \
-      | sed 's|^\./||' \
-      | grep -Ei "$DESIGN_DOC_EXTENSIONS_REGEX")
-  done
+  build_analyze_project_prune_path_args
+  build_analyze_project_iname_or_args "${DESIGN_DOC_PATTERNS[@]}"
+  while IFS= read -r f; do
+    [ -n "$f" ] && results+=("$f")
+  done < <(cd "$dir" 2>/dev/null && find . \
+    \( "${ANALYZE_PROJECT_PRUNE_PATH_ARGS[@]}" \) -prune \
+    -o -type f \( "${ANALYZE_PROJECT_INAME_OR_ARGS[@]}" \) -print 2>/dev/null \
+    | sed 's|^\./||' \
+    | grep -Ei "$DESIGN_DOC_EXTENSIONS_REGEX")
   local design_docs_json
   design_docs_json=$(printf '%s\n' "${results[@]:-}" | awk 'NF' | sort -u | jq -R -s 'split("\n") | map(select(length>0))')
 
@@ -566,12 +621,12 @@ fetch_named_dirs() {
   local -a names=("$@")
   local -a results=()
   local name
+  build_analyze_project_prune_path_args
   for name in "${names[@]}"; do
     while IFS= read -r f; do
       [ -n "$f" ] && results+=("$f")
     done < <(cd "$dir" 2>/dev/null && find . \
-      \( -path "./.git" -o -path "./node_modules" -o -path "./dist" -o -path "./.next" \
-         -o -path "./target" -o -path "./__pycache__" -o -path "./.venv" -o -path "./vendor" \) -prune \
+      \( "${ANALYZE_PROJECT_PRUNE_PATH_ARGS[@]}" \) -prune \
       -o -type d -name "$name" -print 2>/dev/null | sed 's|^\./||')
   done
   printf '%s\n' "${results[@]:-}" | awk 'NF' | sort -u | jq -R -s 'split("\n") | map(select(length>0))'
@@ -596,9 +651,9 @@ fetch_colocated_tests() {
   # fetch_test_dirs が検出する専用テストディレクトリ（__tests__/test/tests/spec）配下の
   # *.test.*/*.spec.* は「co-located」ではなく通常のテスト配置なので除外する
   # （(^|/)(name)/ でパス区切り境界を厳密化し、"latest/" 等の部分一致誤検出を防ぐ）
+  build_analyze_project_prune_path_args
   hit=$(cd "$dir" 2>/dev/null && find . \
-    \( -path "./.git" -o -path "./node_modules" -o -path "./dist" -o -path "./.next" \
-       -o -path "./target" -o -path "./__pycache__" -o -path "./.venv" -o -path "./vendor" \) -prune \
+    \( "${ANALYZE_PROJECT_PRUNE_PATH_ARGS[@]}" \) -prune \
     -o -type f \( -iname "*.test.*" -o -iname "*.spec.*" \) -print 2>/dev/null \
     | sed 's|^\./||' \
     | grep -Ev '(^|/)(__tests__|test|tests|spec)/' \
@@ -712,9 +767,9 @@ fetch_axes() {
 
   local has_openapi="false"
   local openapi_hit
+  build_analyze_project_prune_path_args
   openapi_hit=$(cd "$dir" 2>/dev/null && find . \
-    \( -path "./.git" -o -path "./node_modules" -o -path "./dist" -o -path "./.next" \
-       -o -path "./target" -o -path "./__pycache__" -o -path "./.venv" -o -path "./vendor" \) -prune \
+    \( "${ANALYZE_PROJECT_PRUNE_PATH_ARGS[@]}" \) -prune \
     -o -iname "openapi*" -print -o -iname "swagger*" -print 2>/dev/null | LC_ALL=C sort | head -1)
   [ -n "$openapi_hit" ] && has_openapi="true"
 

--- a/scripts/check-e2e-traceability.sh
+++ b/scripts/check-e2e-traceability.sh
@@ -32,14 +32,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # criteria JSON と trace JSON の文字列を受け取り、突合結果をグローバル変数 RESULT_JSON に格納する。

--- a/scripts/check-subtask-completion.sh
+++ b/scripts/check-subtask-completion.sh
@@ -59,34 +59,15 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # --- gh を呼ぶ関数 ---
 
-# owner/repo をリポジトリ設定から解決する。
-# 結果: REPO_OWNER, REPO_NAME
-resolve_repo() {
-  local json
-  if ! json=$(gh repo view --json owner,name 2>/dev/null); then
-    echo "Error: failed to resolve owner/repo via gh repo view" >&2
-    return 1
-  fi
-  REPO_OWNER=$(jq -r '.owner.login' <<<"$json")
-  REPO_NAME=$(jq -r '.name' <<<"$json")
-  if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
-    echo "Error: could not parse owner/repo from gh repo view output" >&2
-    return 1
-  fi
-  return 0
-}
+# resolve_repo は lib/common.sh（scripts/lib/common.sh）に集約。
 
 # Sub-issues API で子Issue一覧の生JSON配列を取得する。
 # 引数: parent_issue, owner, repo

--- a/scripts/ci-wait.sh
+++ b/scripts/ci-wait.sh
@@ -43,6 +43,12 @@
 
 set -u
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
+}
+
 DEFAULT_TIMEOUT_SECONDS=900
 DEFAULT_POLL_INTERVAL_SECONDS=30
 NONE_CONFIRM_ATTEMPTS=2
@@ -50,15 +56,6 @@ LOG_TAIL_LINES=100
 LOG_CHAR_BUDGET=4000
 
 POLL_SLEEP_CMD="${POLL_SLEEP_CMD:-sleep}"
-
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
-}
 
 # ---------------------------------------------------------------------------
 # gh 呼び出し（外部作用あり）
@@ -76,18 +73,8 @@ fetch_pr_view() {
   return 0
 }
 
-# pr-merge-preflight.sh の fetch_pr_checks と同じ設計（gh pr checks は pending/fail 時に
-# 非0 exitを返す仕様のため、exit code ではなく stdout が有効なJSON配列かどうかで成否判定）。
-fetch_pr_checks() {
-  local pr_num="$1"
-  local output
-  output=$(gh pr checks "$pr_num" --json name,state,bucket,description,workflow,link 2>/dev/null)
-  if [ -z "$output" ] || ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
-    printf '[]'
-    return 0
-  fi
-  printf '%s' "$output"
-}
+# fetch_pr_checks は lib/common.sh（scripts/lib/common.sh）に集約（pr-merge-preflight.sh と
+# 同じ実装。ここでは warn_on_empty を渡さないため Warning は出さない元の挙動を維持する）。
 
 # 失敗ジョブのログ末尾を取得する。run_id 単位（複数チェックが同一 run に属しうる）。
 fetch_run_log_failed() {
@@ -110,7 +97,7 @@ classify_checks() {
     echo "empty"
     return
   fi
-  if jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<<"$checks_json" >/dev/null 2>&1; then
+  if jq -e "any(.[]; ${JQ_FAIL_CANCEL_PREDICATE})" <<<"$checks_json" >/dev/null 2>&1; then
     echo "red"
     return
   fi
@@ -179,7 +166,7 @@ extract_run_id() {
 # fail/cancel の checks のみを抽出したJSON配列を返す。
 build_failed_checks_json() {
   local checks_json="$1"
-  jq -c '[.[] | select(.bucket == "fail" or .bucket == "cancel") | {name, workflow, link}]' <<<"$checks_json"
+  jq -c "[.[] | select(${JQ_FAIL_CANCEL_PREDICATE}) | {name, workflow, link}]" <<<"$checks_json"
 }
 
 # failed_checks_json（build_failed_checks_json の出力）から一意な run_id 一覧を返す

--- a/scripts/collect-impl-context.sh
+++ b/scripts/collect-impl-context.sh
@@ -34,14 +34,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # gh issue view で親Issue本文を取得する。

--- a/scripts/collect-promotion-context.sh
+++ b/scripts/collect-promotion-context.sh
@@ -50,14 +50,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # git fetch origin を best-effort で実行する（gh を呼ばない。git のみ）。

--- a/scripts/collect-review-diff.sh
+++ b/scripts/collect-review-diff.sh
@@ -52,14 +52,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # BASE未指定時のフォールバック解決。gh を呼ぶため純粋関数ではない。

--- a/scripts/create-debt-issues.sh
+++ b/scripts/create-debt-issues.sh
@@ -51,19 +51,15 @@
 
 set -u
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
+}
+
 # 粒度ヒューリスティックの閾値。targetFilesの件数がこれを超える項目には
 # 対応表の結果に warning フィールドを付ける（起票は止めない。機械的カウントのみ）。
 TARGET_FILES_WARNING_THRESHOLD=5
-
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
-}
 
 # 1件のmanifest項目（JSONオブジェクト文字列）の必須フィールドを検証する。gh を呼ばない純粋関数。
 # 引数: item_json（JSONオブジェクト文字列）

--- a/scripts/extract-acceptance-criteria.sh
+++ b/scripts/extract-acceptance-criteria.sh
@@ -21,14 +21,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # gh issue view で Issue 本文を取得する。

--- a/scripts/extract-hunk.sh
+++ b/scripts/extract-hunk.sh
@@ -27,13 +27,10 @@
 
 set -u
 
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # diff_fileの中からtarget_file/target_lineに該当するhunk（＋前後context_lines行）を

--- a/scripts/fetch-pr-comments.sh
+++ b/scripts/fetch-pr-comments.sh
@@ -56,14 +56,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # author login からボット判定を行う純粋関数（gh を呼ばない）。
@@ -90,22 +86,7 @@ is_bot_author() {
 
 # --- gh を呼ぶ取得系関数 ---
 
-# owner/repo をリポジトリ設定から解決する。
-# 結果: REPO_OWNER, REPO_NAME
-resolve_repo() {
-  local json
-  if ! json=$(gh repo view --json owner,name 2>/dev/null); then
-    echo "Error: failed to resolve owner/repo via gh repo view" >&2
-    return 1
-  fi
-  REPO_OWNER=$(jq -r '.owner.login' <<<"$json")
-  REPO_NAME=$(jq -r '.name' <<<"$json")
-  if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
-    echo "Error: could not parse owner/repo from gh repo view output" >&2
-    return 1
-  fi
-  return 0
-}
+# resolve_repo は lib/common.sh（scripts/lib/common.sh）に集約。
 
 # 引数: PR番号
 # 戻り値: stdout に `gh pr view --json reviews` の生JSON

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# scripts/lib/common.sh
+# scripts/*.sh 間で重複していた共通ヘルパーを集約したライブラリ（Issue #128）。
+# 各スクリプトはスクリプト自身の位置起点で source する（呼び出し元の cwd に依存させないため）:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+#
+# 既存の「対象スクリプトを source して関数を直接テストする」方式（scripts/README.md
+# 「テスト」節）と両立するよう、ここに定義する関数もトップレベル関数として定義する
+# （サブシェル化しない。単独で `bash scripts/lib/common.sh` として実行することは想定しない）。
+#
+# 適用範囲について: scripts/*.sh 配下の18スクリプトが対象（Issue #128 の実測範囲）。
+# skills/init-project/scripts/generate-settings.sh にも同型の check_jq 実装（gs_check_jq）が
+# 存在するが、(1) skills/*/scripts/ は scripts/ とは別のディレクトリ境界であり、本ライブラリの
+# source パス解決（スクリプト自身の位置起点の相対パス）がそのままでは届かないこと、
+# (2) skills↔scripts間の参照を増やす設計判断は本Issueのスコープ外であること、の2点から
+# 意図的に対象外としている（見送り）。
+#
+# 提供する関数・変数:
+#   - check_jq [error_json]
+#       jq の有無を確認する。無ければ stderr にエラーメッセージ + エラーJSONを出し非0を返す。
+#       error_json 省略時は '{"error":"jq not found"}'。analyze-project.sh のみ元実装が
+#       '{"status":"error","error":"jq not found"}' を出力していたため、analyze-project.sh は
+#       source 後に check_jq を自スクリプト専用のエラーJSONへ束縛するローカルラッパーで上書きする
+#       （呼び出し箇所ごとに引数を渡し忘れるリスクを無くすため。_common_check_jq_impl 参照）。
+#   - resolve_repo
+#       `gh repo view` から owner/repo を解決し、グローバル変数 REPO_OWNER / REPO_NAME に
+#       格納する。3スクリプト（fetch-pr-comments.sh / reply-and-resolve.sh /
+#       check-subtask-completion.sh）で完全に同一実装だったものを集約。
+#   - fetch_pr_checks <pr_num> [warn_on_empty]
+#       `gh pr checks` の結果を取得する。取得失敗/空の場合は空配列を返す。
+#       gh pr checks は CI が pending/fail の場合に非0 exitを返す仕様のため、
+#       exit code ではなく stdout が有効なJSON配列かどうかで成否を判定する。
+#       warn_on_empty に "1" を渡すと取得失敗/空の際に stderr へ Warning を出す
+#       （pr-merge-preflight.sh の元実装の挙動）。省略時は Warning を出さない
+#       （ci-wait.sh の元実装の挙動。2つの元実装の唯一の差分だったため引数化した）。
+#   - JQ_FAIL_CANCEL_PREDICATE
+#       CIチェックの fail/cancel 判定に使う jq 式の述語部分（4箇所で重複していたもの）。
+#       利用側は `jq -e "any(.[]; ${JQ_FAIL_CANCEL_PREDICATE})"` や
+#       `jq -c "[.[] | select(${JQ_FAIL_CANCEL_PREDICATE})]"` のように埋め込んで使う
+#       （完全な jq プログラム自体は呼び出し箇所ごとに異なる= any/select 等の外側の形が
+#       異なるため、共通化対象は述語部分の文字列に留める）。
+
+# check_jq の実体。error_json 引数を必須で取る内部実装。check_jq（既定JSON）と
+# analyze-project.sh 側のローカル上書き（自スクリプト専用JSON）の両方から呼ばれる共通コア。
+_common_check_jq_impl() {
+  local error_json="$1"
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but was not found in PATH" >&2
+    printf '%s\n' "$error_json" >&2
+    return 1
+  fi
+  return 0
+}
+
+check_jq() {
+  local error_json="${1:-}"
+  if [ -z "$error_json" ]; then
+    error_json='{"error":"jq not found"}'
+  fi
+  _common_check_jq_impl "$error_json"
+}
+
+resolve_repo() {
+  local json
+  if ! json=$(gh repo view --json owner,name 2>/dev/null); then
+    echo "Error: failed to resolve owner/repo via gh repo view" >&2
+    return 1
+  fi
+  REPO_OWNER=$(jq -r '.owner.login' <<<"$json")
+  REPO_NAME=$(jq -r '.name' <<<"$json")
+  if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
+    echo "Error: could not parse owner/repo from gh repo view output" >&2
+    return 1
+  fi
+  return 0
+}
+
+fetch_pr_checks() {
+  local pr_num="$1"
+  local warn_on_empty="${2:-}"
+  local output
+  output=$(gh pr checks "$pr_num" --json name,state,bucket,description,workflow,link 2>/dev/null)
+  if [ -z "$output" ] || ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
+    if [ "$warn_on_empty" = "1" ]; then
+      echo "Warning: no CI checks data available for PR #${pr_num} (no checks configured, or fetch failed)" >&2
+    fi
+    printf '[]'
+    return 0
+  fi
+  printf '%s' "$output"
+}
+
+# shellcheck disable=SC2034 # source する各スクリプト側の jq 式に文字列展開して使われる
+JQ_FAIL_CANCEL_PREDICATE='.bucket == "fail" or .bucket == "cancel"'

--- a/scripts/mutation-run.sh
+++ b/scripts/mutation-run.sh
@@ -56,13 +56,10 @@
 
 set -u
 
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 print_usage() {

--- a/scripts/pr-merge-preflight.sh
+++ b/scripts/pr-merge-preflight.sh
@@ -40,6 +40,12 @@
 
 set -u
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
+}
+
 # 変数名は source する側（テストファイル等）の SCRIPT_DIR と衝突しないよう
 # このスクリプト専用の名前にしている（source すると同名グローバル変数は上書きされるため）。
 PR_MERGE_PREFLIGHT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -64,16 +70,6 @@ DEFAULT_SENSITIVE_PATTERNS=(
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-60}"
 POLL_SLEEP_CMD="${POLL_SLEEP_CMD:-sleep}"
 DEFAULT_TIMEOUT_SECONDS=600
-
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
-}
 
 # ---------------------------------------------------------------------------
 # gh 呼び出し（外部作用あり）
@@ -115,22 +111,8 @@ fetch_pr_view() {
   printf '%s' "$output"
 }
 
-# CI チェック結果を取得する。
-# gh pr checks は CI が pending/fail の場合に非0 exitを返す仕様のため、
-# exit code ではなく stdout が有効なJSON配列かどうかで成否を判定する
-# （非0 exit = 失敗、とは限らないため）。
-# チェックが1件も無い/取得できない場合は空配列を返す（非致命）。
-fetch_pr_checks() {
-  local pr_num="$1"
-  local output
-  output=$(gh pr checks "$pr_num" --json name,state,bucket,description,workflow,link 2>/dev/null)
-  if [ -z "$output" ] || ! jq -e 'type == "array"' <<<"$output" >/dev/null 2>&1; then
-    echo "Warning: no CI checks data available for PR #${pr_num} (no checks configured, or fetch failed)" >&2
-    printf '[]'
-    return 0
-  fi
-  printf '%s' "$output"
-}
+# fetch_pr_checks は lib/common.sh（scripts/lib/common.sh）に集約（ci-wait.sh と同じ実装。
+# ここでは warn_on_empty=1 を渡し、取得失敗/空の際に Warning を出す元の挙動を維持する）。
 
 # ポーリングループ用の軽量な reviews 再取得。
 fetch_pr_reviews_only() {
@@ -203,7 +185,7 @@ determine_ci_status() {
     echo "none"
     return
   fi
-  if jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<<"$checks_json" >/dev/null 2>&1; then
+  if jq -e "any(.[]; ${JQ_FAIL_CANCEL_PREDICATE})" <<<"$checks_json" >/dev/null 2>&1; then
     echo "fail"
     return
   fi
@@ -237,7 +219,7 @@ judge_blocking() {
     blocking="true"
   fi
 
-  if jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<<"$checks_json" >/dev/null 2>&1; then
+  if jq -e "any(.[]; ${JQ_FAIL_CANCEL_PREDICATE})" <<<"$checks_json" >/dev/null 2>&1; then
     reasons=$(jq -c '. + ["ci_failed"]' <<<"$reasons")
     blocking="true"
   fi
@@ -410,7 +392,7 @@ main() {
   # 再取得する（ポーリング中にCIが完了したり、他の変更でmergeableやfilesが変わったりする場合、
   # ポーリング開始前の古いスナップショットのまま judge_blocking / risk算出に渡ってしまうため）。
   local checks_json
-  checks_json="$(fetch_pr_checks "$pr_num")"
+  checks_json="$(fetch_pr_checks "$pr_num" 1)"
 
   local ci_status
   ci_status="$(determine_ci_status "$checks_json")"

--- a/scripts/quality-check-runner.sh
+++ b/scripts/quality-check-runner.sh
@@ -49,17 +49,10 @@
 
 set -u
 
-# ---------------------------------------------------------------------------
-# 前提チェック
-# ---------------------------------------------------------------------------
-
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/reply-and-resolve.sh
+++ b/scripts/reply-and-resolve.sh
@@ -58,17 +58,13 @@
 
 set -u
 
-MARKER_PREFIX="pr-review-respond"
-
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
+
+MARKER_PREFIX="pr-review-respond"
 
 # --- 純粋関数（gh を呼ばない） ---
 
@@ -113,22 +109,7 @@ EOF
 
 # --- gh を呼ぶ関数 ---
 
-# owner/repo をリポジトリ設定から解決する。
-# 結果: REPO_OWNER, REPO_NAME
-resolve_repo() {
-  local json
-  if ! json=$(gh repo view --json owner,name 2>/dev/null); then
-    echo "Error: failed to resolve owner/repo via gh repo view" >&2
-    return 1
-  fi
-  REPO_OWNER=$(jq -r '.owner.login' <<<"$json")
-  REPO_NAME=$(jq -r '.name' <<<"$json")
-  if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
-    echo "Error: could not parse owner/repo from gh repo view output" >&2
-    return 1
-  fi
-  return 0
-}
+# resolve_repo は lib/common.sh（scripts/lib/common.sh）に集約。
 
 # threadIdが非nullの項目向けの既存コメント本文一覧を取得する。
 # 引数: PR番号, owner, repo

--- a/scripts/spec-lint.sh
+++ b/scripts/spec-lint.sh
@@ -40,14 +40,10 @@
 
 set -u
 
-# jq の有無をチェックする。無ければ stderr にエラーメッセージ + エラーJSONを出す。
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # 曖昧語辞書（単一定義）。severity判定はしない候補列挙のみのため、多少広めに定義してよい。

--- a/scripts/tests/test-analyze-project.sh
+++ b/scripts/tests/test-analyze-project.sh
@@ -697,6 +697,27 @@ NONEXISTENT_EXIT=$?
 assert_eq "存在しないディレクトリはexit非0" "1" "$NONEXISTENT_EXIT"
 assert_eq "statusがerror" "error" "$(jq -r '.status' <<<"$NONEXISTENT_OUTPUT")"
 
+# ====================================================================
+# check_jq（analyze-project.sh 独自のエラーJSON上書き。lib/common.sh 集約後の回帰。Issue #128）
+# ====================================================================
+# analyze-project.sh は source 後、lib/common.sh の check_jq（既定エラーJSON）を
+# 自スクリプト専用のエラーJSON（status フィールド付き）へ束縛したローカル版で上書きする。
+# この上書きが本番コードパス（CLI実行）でも効いていることを、jqが見つからないPATHで
+# 直接 $TARGET_SCRIPT を実行して確認する（sourceされた関数を直接呼ぶだけでは、
+# 上書きのブロック順序が崩れて既定JSONへ静かにフォールバックする回帰を検出できないため）。
+echo "=== test: check_jq (analyze-project.sh固有のエラーJSON上書きがCLI実行でも効く、回帰) ==="
+# PATH を jq だけ見つからない最小構成にする（完全な空PATHだと source 行が使う外部コマンド
+# dirname 自体が見つからずソース失敗のガード側に倒れてしまい、check_jq を検証できないため）。
+JQ_ABSENT_PATH_DIR="$(mktemp -d)"
+ln -s "$(command -v dirname)" "${JQ_ABSENT_PATH_DIR}/dirname"
+JQ_ABSENT_STDERR=$(PATH="$JQ_ABSENT_PATH_DIR" "$TARGET_SCRIPT" 2>&1 1>/dev/null)
+JQ_ABSENT_EXIT_CHECK=$(PATH="$JQ_ABSENT_PATH_DIR" "$TARGET_SCRIPT" >/dev/null 2>&1; echo $?)
+rm -rf "$JQ_ABSENT_PATH_DIR"
+assert_eq "jq不在時はexit非0" "1" "$JQ_ABSENT_EXIT_CHECK"
+assert_eq "jq不在時のstderr最終行はstatusフィールド付きエラーJSON(lib/common.shの既定にフォールバックしない)" \
+  '{"status":"error","error":"jq not found"}' \
+  "$(printf '%s\n' "$JQ_ABSENT_STDERR" | tail -n 1)"
+
 echo ""
 echo "=== summary ==="
 echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"

--- a/scripts/tests/test-lib-common.sh
+++ b/scripts/tests/test-lib-common.sh
@@ -116,6 +116,24 @@ echo "=== fetch_pr_checks ==="
     "Warning: no CI checks data available for PR #42 (no checks configured, or fetch failed)" \
     "$stderr_warn"
 
+  # exit code非依存の設計意図を固定する回帰テスト。gh pr checks は CI が pending/fail の
+  # 場合に非0 exitを返す仕様のため、fetch_pr_checks は exit code を見ず「出力の非空性 +
+  # jq -e 'type == "array"'」のみで採否を判定する設計になっている（scripts/lib/common.sh
+  # 内コメント参照）。exit code 判定へ書き換える退行を検出できるよう、
+  # 「非0 exitでも有効な配列は採用する」ケースと「rc=0でも非配列出力は棄却する」ケースの
+  # 両方を検証する。
+  gh() { echo '[{"bucket":"fail"}]'; return 1; }
+  result_nonzero_valid="$(fetch_pr_checks 42)"
+  assert_eq "非0 exitでも有効なJSON配列ならそのまま返す(exit code非依存)" \
+    '[{"bucket":"fail"}]' \
+    "$result_nonzero_valid"
+
+  gh() { echo 'not json'; return 0; }
+  result_zero_invalid="$(fetch_pr_checks 42)"
+  assert_eq "rc=0でも非JSON配列出力なら空配列を返す(jq判定が主体)" \
+    "[]" \
+    "$result_zero_invalid"
+
   unset -f gh
 }
 

--- a/scripts/tests/test-lib-common.sh
+++ b/scripts/tests/test-lib-common.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# test-lib-common.sh
+# scripts/lib/common.sh の共通ヘルパー（check_jq / resolve_repo / fetch_pr_checks /
+# JQ_FAIL_CANCEL_PREDICATE）を、外部コマンド（gh/jq の可用性）をスタブしつつ直接テストする。
+#
+# 実行方法: bash scripts/tests/test-lib-common.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_LIB="${SCRIPT_DIR}/../lib/common.sh"
+
+# shellcheck source=/dev/null
+source "$TARGET_LIB"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+assert_eq() {
+  local description="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${description}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("$description")
+    echo "  NG - ${description}"
+    echo "       expected: ${expected}"
+    echo "       actual:   ${actual}"
+  fi
+}
+
+echo "=== check_jq ==="
+{
+  assert_eq "jqが存在する環境ではcheck_jqは0を返す" "0" "$(check_jq; echo $?)"
+
+  # command -v jq を失敗させるため、PATH をコマンドが見つからないディレクトリに限定する
+  # （builtin/functionは影響を受けないためサブシェルに閉じ込めて安全に検証する）。
+  empty_path_dir="$(mktemp -d)"
+  trap 'rm -rf "$empty_path_dir"' EXIT
+
+  stderr_default="$(PATH="$empty_path_dir" check_jq 2>&1 1>/dev/null)"
+  exit_default="$(PATH="$empty_path_dir" check_jq >/dev/null 2>&1; echo $?)"
+  assert_eq "jq不在時はデフォルトのエラーJSONをstderrに出す" \
+    '{"error":"jq not found"}' \
+    "$(printf '%s\n' "$stderr_default" | tail -n 1)"
+  assert_eq "jq不在時は非0を返す(デフォルト)" "1" "$exit_default"
+
+  stderr_custom="$(PATH="$empty_path_dir" check_jq '{"status":"error","error":"jq not found"}' 2>&1 1>/dev/null)"
+  exit_custom="$(PATH="$empty_path_dir" check_jq '{"status":"error","error":"jq not found"}' >/dev/null 2>&1; echo $?)"
+  assert_eq "jq不在時は引数で渡したエラーJSONをstderrに出す(analyze-project.sh向け)" \
+    '{"status":"error","error":"jq not found"}' \
+    "$(printf '%s\n' "$stderr_custom" | tail -n 1)"
+  assert_eq "jq不在時は非0を返す(カスタムエラーJSON指定時も)" "1" "$exit_custom"
+  assert_eq "jq不在時のstderr1行目は共通のエラーメッセージ(カスタムエラーJSON指定時も)" \
+    "Error: jq is required but was not found in PATH" \
+    "$(printf '%s\n' "$stderr_custom" | sed -n '1p')"
+
+  rm -rf "$empty_path_dir"
+  trap - EXIT
+}
+
+echo ""
+echo "=== resolve_repo ==="
+{
+  gh() {
+    if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+      echo '{"owner":{"login":"masanami"},"name":"claude-harness"}'
+      return 0
+    fi
+    return 1
+  }
+
+  REPO_OWNER=""
+  REPO_NAME=""
+  resolve_repo
+  rc=$?
+  assert_eq "resolve_repo成功時は0を返す" "0" "$rc"
+  assert_eq "resolve_repo成功時はREPO_OWNERを設定する" "masanami" "$REPO_OWNER"
+  assert_eq "resolve_repo成功時はREPO_NAMEを設定する" "claude-harness" "$REPO_NAME"
+
+  gh() { return 1; }
+  REPO_OWNER=""
+  REPO_NAME=""
+  resolve_repo >/dev/null 2>&1
+  assert_eq "gh repo view失敗時は非0を返す" "1" "$?"
+
+  unset -f gh
+}
+
+echo ""
+echo "=== fetch_pr_checks ==="
+{
+  gh() {
+    if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+      echo '[{"name":"build","state":"SUCCESS","bucket":"pass","description":"","workflow":"CI","link":"l"}]'
+      return 0
+    fi
+    return 1
+  }
+  result="$(fetch_pr_checks 42)"
+  assert_eq "gh成功時はそのままJSON配列を返す" \
+    '[{"name":"build","state":"SUCCESS","bucket":"pass","description":"","workflow":"CI","link":"l"}]' \
+    "$result"
+
+  gh() { echo ""; return 1; }
+  result_empty="$(fetch_pr_checks 42)"
+  assert_eq "gh失敗/空出力時は空配列を返す" "[]" "$result_empty"
+
+  stderr_no_warn="$(gh() { echo ""; return 1; }; fetch_pr_checks 42 2>&1 1>/dev/null)"
+  assert_eq "warn_on_empty省略時はWarningを出さない(ci-wait.sh互換)" "" "$stderr_no_warn"
+
+  stderr_warn="$(gh() { echo ""; return 1; }; fetch_pr_checks 42 1 2>&1 1>/dev/null)"
+  assert_eq "warn_on_empty=1指定時はWarningをstderrに出す(pr-merge-preflight.sh互換)" \
+    "Warning: no CI checks data available for PR #42 (no checks configured, or fetch failed)" \
+    "$stderr_warn"
+
+  unset -f gh
+}
+
+echo ""
+echo "=== JQ_FAIL_CANCEL_PREDICATE ==="
+{
+  assert_eq "述語文字列が期待値と一致する" \
+    '.bucket == "fail" or .bucket == "cancel"' \
+    "$JQ_FAIL_CANCEL_PREDICATE"
+
+  checks_with_fail='[{"bucket":"pass"},{"bucket":"fail"}]'
+  any_result="$(jq -e "any(.[]; ${JQ_FAIL_CANCEL_PREDICATE})" <<<"$checks_with_fail" >/dev/null 2>&1; echo $?)"
+  assert_eq "any(...)形式で組み込んでfail検出できる" "0" "$any_result"
+
+  checks_all_pass='[{"bucket":"pass"},{"bucket":"skipping"}]'
+  any_result2="$(jq -e "any(.[]; ${JQ_FAIL_CANCEL_PREDICATE})" <<<"$checks_all_pass" >/dev/null 2>&1; echo $?)"
+  assert_eq "fail/cancel無しではany(...)は非0" "1" "$any_result2"
+
+  checks_with_cancel='[{"bucket":"cancel"}]'
+  select_result="$(jq -c "[.[] | select(${JQ_FAIL_CANCEL_PREDICATE})]" <<<"$checks_with_cancel")"
+  assert_eq "select(...)形式で組み込んでcancelを抽出できる" '[{"bucket":"cancel"}]' "$select_result"
+}
+
+echo ""
+echo "=== summary ==="
+echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - ${t}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/tests/test-pr-merge-preflight.sh
+++ b/scripts/tests/test-pr-merge-preflight.sh
@@ -324,6 +324,58 @@ rm -f "$CHECKS_CALL_COUNT_FILE" "$RECHECK_CALL_COUNT_FILE"
 unset -f fetch_default_branch fetch_pr_view fetch_pr_reviews_only fetch_pr_checks fetch_pr_recheck fetch_pr_review_decision
 
 # =============================================================================
+echo "=== test: main() 内の fetch_pr_checks 呼び出し合成(warn_on_empty=1)の回帰テスト ==="
+# =============================================================================
+# L395 の `fetch_pr_checks "$pr_num" 1` という呼び出し側の引数合成
+# （warn_on_empty=1。「preflight だけが空/失敗時に stderr Warning を出す」挙動の唯一の
+# 根拠）を固定する。fetch_pr_checks 自体はモックせず、scripts/lib/common.sh の実装を
+# そのまま通す経路で検証する（直前ブロックの `unset -f fetch_pr_checks` により関数定義
+# そのものが失われているため、ここで lib/common.sh を再sourceして実物を復元する。
+# 同じ理由で fetch_default_branch 等の pr-merge-preflight.sh 固有関数も直前ブロックの
+# unset -f で失われているため、以下ですべて再定義（モック）する。gh は
+# `pr checks` のみ最小スタブし、実物の fetch_pr_checks がそれを経由する）。
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+# shellcheck disable=SC2329  # main から間接的に呼ばれる（関数上書き）
+fetch_default_branch() { printf 'main'; }
+# shellcheck disable=SC2329  # main から間接的に呼ばれる（関数上書き）
+fetch_pr_view() { printf '{"baseRefName":"main","reviews":[]}'; }
+# shellcheck disable=SC2329  # main から間接的に呼ばれる（関数上書き）
+fetch_pr_reviews_only() { printf '[]'; }
+# shellcheck disable=SC2329  # main から間接的に呼ばれる（関数上書き）
+fetch_pr_recheck() {
+  printf '{"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","files":[],"additions":0,"deletions":0,"changedFiles":0}'
+}
+# shellcheck disable=SC2329  # main から間接的に呼ばれる（関数上書き）
+fetch_pr_review_decision() { printf 'APPROVED'; }
+
+# gh pr checks のみ「空出力+失敗」を返す最小スタブ（fetch_pr_checks は common.sh の実物）
+# shellcheck disable=SC2329  # fetch_pr_checks(common.sh実物)から間接的に呼ばれる
+gh() {
+  if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+    printf ''
+    return 1
+  fi
+  return 1
+}
+
+WARN_STDERR_FILE="$(mktemp)"
+# timeout=0 -> max_attempts=1 でポーリングループに入らず即確定する
+MAIN_OUTPUT_WARN="$(main "999" 0 2>"$WARN_STDERR_FILE")"
+
+assert_eq "main()経由のfetch_pr_checks呼び出し(warn_on_empty=1合成)はCI空時にWarningをstderrへ出す" \
+  "1" \
+  "$(grep -c 'Warning: no CI checks data available for PR #999' "$WARN_STDERR_FILE")"
+assert_eq "main()経由でもCI空時はci.statusがnoneになる(fetch_pr_checksが空配列を返す経路の確認)" \
+  "none" \
+  "$(jq -r '.ci.status' <<<"$MAIN_OUTPUT_WARN")"
+
+rm -f "$WARN_STDERR_FILE"
+unset -f fetch_default_branch fetch_pr_view fetch_pr_reviews_only fetch_pr_recheck fetch_pr_review_decision gh
+
+# =============================================================================
 echo "=== test: CLIレベル（引数バリデーション。ghを呼ばない） ==="
 # =============================================================================
 

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -25,13 +25,10 @@
 
 set -u
 
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -48,16 +48,13 @@
 
 set -u
 
-WORKTREE_SETUP_BRANCH_TYPES="feature fix refactor docs hotfix"
-
-check_jq() {
-  if ! command -v jq &>/dev/null; then
-    echo "Error: jq is required but was not found in PATH" >&2
-    printf '{"error":"jq not found"}\n' >&2
-    return 1
-  fi
-  return 0
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
 }
+
+WORKTREE_SETUP_BRANCH_TYPES="feature fix refactor docs hotfix"
 
 # ---------------------------------------------------------------------------
 # 純粋関数（git/ghを呼ばない）


### PR DESCRIPTION
## 概要

scripts/*.sh に散在していた共通ヘルパーの重複実装を `scripts/lib/common.sh` へ集約し、各スクリプトから `source` する形に統一した。あわせて `analyze-project.sh` の走査効率化を行った。

## 変更内容

1. `scripts/lib/common.sh` を新設し、以下を集約:
   - `check_jq`（18スクリプトに同一実装、約140行分）
   - `resolve_repo`（fetch-pr-comments.sh / reply-and-resolve.sh / check-subtask-completion.sh の3本）
   - `fetch_pr_checks`（ci-wait.sh と pr-merge-preflight.sh の2本）
   - fail/cancel 判定 jq 式（4箇所）
   - source パスはスクリプト自身の位置起点（`"$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"`）で解決し、呼び出し元の cwd に依存しない
2. `analyze-project.sh`:
   - 8ディレクトリ除外の `-prune` 節5コピーを共通のビルダー関数に一本化
   - `fetch_docs_evidence` の16パターン個別 find 実行を `-iname`/`-o` で連結した1回の find に統合
3. `scripts/tests/test-lib-common.sh` を新設（lib/common.sh 自体のテスト）
4. 既存スクリプトの出力JSON・exit code の挙動は変更なし（既存テストが挙動固定のセーフティネット）

## 発見された実装差分（挙動温存）

実装過程で「同一実装」ではなく微差がある箇所を発見し、挙動を変えない形で吸収した:
- `check_jq`: analyze-project.sh のみエラーJSONに `status` フィールドを含む → `check_jq(error_json)` 引数化+ローカルオーバーライドで温存
- `fetch_pr_checks`: pr-merge-preflight.sh のみ空/失敗時に stderr Warning を出す → `warn_on_empty` 引数化
- analyze-project.sh の5つの prune 節: `fetch_dir_tree` のみ任意深度prune、他4つはトップレベルのみ prune → 2つのビルダー関数で温存

## テスト結果

- `scripts/tests/test-*.sh` 全21ファイル: 全通過（951アサーション、0失敗）
- lint（`bash -n` + `shellcheck -S warning`、本PRの変更/新規ファイル21本に対して）: 0 issue
- `/self-review`: 3ラウンドで収束（correctness上の未解決指摘 0件）

## スコープ外

- scripts/README.md・スクリプトヘッダコメントの記述は変更していない（#126・#127の担当領域）
- E2E対象外（スクリプトのリファクタのみ、ユーザー可視の機能変更なし）

Closes #128