### PR TITLE
feat(demo): run-walkthrough.mjs に WALKTHROUGH_PAUSE_MS（ステップ間自動静止）を追加

### DIFF
--- a/scripts/tests/test-run-walkthrough-pause-ms.sh
+++ b/scripts/tests/test-run-walkthrough-pause-ms.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# test-run-walkthrough-pause-ms.sh
+# skills/demo/scripts/run-walkthrough.mjs が WALKTHROUGH_PAUSE_MS をパースする際の
+# 純粋関数 parsePauseMs（skills/demo/scripts/lib/parse-pause-ms.mjs）を検証する（Issue #148）。
+#
+# run-walkthrough.mjs 本体は Playwright 起動を伴うため完全な自動テストは困難だが、
+# env パース部分（正の整数のみ受理・不正値は無効化＝静止しない）は副作用の無い
+# 純粋関数に切り出してあるため、node の ESM 動的評価経由で外部コマンドを叩かずに検証できる。
+#
+# 実行方法: bash scripts/tests/test-run-walkthrough-pause-ms.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PARSE_MODULE="${REPO_ROOT}/skills/demo/scripts/lib/parse-pause-ms.mjs"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "NG - node が見つからないためテストを実行できません"
+  exit 1
+fi
+
+if [ ! -f "$PARSE_MODULE" ]; then
+  echo "NG - ${PARSE_MODULE} が見つかりません"
+  exit 1
+fi
+
+# $1: テスト名, $2: env値をセットするか(1/0), $3: env値(セットする場合), $4: 期待値("null" または数値文字列)
+run_case() {
+  local desc="$1"
+  local set_env="$2"
+  local raw_value="$3"
+  local expected="$4"
+
+  local actual
+  if [ "$set_env" = "1" ]; then
+    actual="$(TEST_PAUSE_MS_RAW="$raw_value" node --input-type=module -e "
+      import { parsePauseMs } from '${PARSE_MODULE}';
+      const result = parsePauseMs(process.env.TEST_PAUSE_MS_RAW);
+      console.log(result === null ? 'null' : String(result));
+    " 2>&1)"
+  else
+    actual="$(node --input-type=module -e "
+      import { parsePauseMs } from '${PARSE_MODULE}';
+      const result = parsePauseMs(undefined);
+      console.log(result === null ? 'null' : String(result));
+    " 2>&1)"
+  fi
+  local node_exit=$?
+
+  if [ "$node_exit" -ne 0 ]; then
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("${desc}: node実行エラー(exit ${node_exit}): ${actual}")
+    echo "  NG - ${desc}: node実行エラー(exit ${node_exit})"
+    echo "       ${actual}"
+    return
+  fi
+
+  if [ "$actual" = "$expected" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${desc}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("${desc}: expected=${expected} actual=${actual}")
+    echo "  NG - ${desc}: expected=${expected} actual=${actual}"
+  fi
+}
+
+echo "=== parsePauseMs: 正の整数は有効値として受理される ==="
+run_case "5000（既定値相当）" 1 "5000" "5000"
+run_case "1（最小の正の整数）" 1 "1" "1"
+run_case "2000（他の正の整数）" 1 "2000" "2000"
+
+echo ""
+echo "=== parsePauseMs: 未指定時は null（＝静止しない。従来挙動） ==="
+run_case "env未指定" 0 "" "null"
+run_case "空文字" 1 "" "null"
+
+echo ""
+echo "=== parsePauseMs: 不正値は無効化され null になる ==="
+run_case "0（正の整数ではない）" 1 "0" "null"
+run_case "負数" 1 "-100" "null"
+run_case "非数値文字列" 1 "abc" "null"
+run_case "小数" 1 "500.5" "null"
+run_case "数値+単位付き文字列" 1 "5000ms" "null"
+run_case "先頭ゼロ付き数値文字列" 1 "0500" "null"
+run_case "16進表記" 1 "0x10" "null"
+run_case "指数表記" 1 "5e3" "null"
+run_case "先頭プラス符号付き" 1 "+5000" "null"
+run_case "前後に空白を含む数値文字列" 1 " 5000 " "null"
+
+echo ""
+echo "=== run-walkthrough.mjs 側の配線チェック（回帰ガード） ==="
+# parsePauseMs 単体は上記で検証済みだが、run-walkthrough.mjs 側で
+# import されていること・ctx.goto / ctx.step の完了直後に実際に
+# waitForTimeout(pauseMs) が呼ばれていることまではここまでのテストでは
+# 検証できない（run-walkthrough.mjs は Playwright 起動を伴うため import 不能）。
+# grep ベースで存在確認する（scripts/tests/test-path-conventions.sh と同じ手法）。
+RUNNER_FILE="${REPO_ROOT}/skills/demo/scripts/run-walkthrough.mjs"
+
+if [ ! -f "$RUNNER_FILE" ]; then
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILED_TESTS+=("run-walkthrough.mjs が見つかりません: ${RUNNER_FILE}")
+  echo "  NG - ${RUNNER_FILE} が見つかりません"
+else
+  # $1: テスト名, $2: 検索パターン(拡張正規表現)
+  assert_runner_contains() {
+    local desc="$1"
+    local pattern="$2"
+    if grep -qE "$pattern" "$RUNNER_FILE"; then
+      PASS_COUNT=$((PASS_COUNT + 1))
+      echo "  ok - ${desc}"
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      FAILED_TESTS+=("${desc}: パターン未検出: ${pattern}")
+      echo "  NG - ${desc}: パターン未検出"
+    fi
+  }
+
+  assert_runner_contains "parsePauseMs を lib/parse-pause-ms.mjs から import している" \
+    "import \{ parsePauseMs \} from '\./lib/parse-pause-ms\.mjs'"
+
+  waitfortimeout_count="$(grep -cE 'if \(pauseMs\) await page\.waitForTimeout\(pauseMs\)' "$RUNNER_FILE")"
+  if [ "$waitfortimeout_count" -ge 2 ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - waitForTimeout(pauseMs) 呼び出しが2箇所以上存在する(ctx.goto/ctx.step想定): ${waitfortimeout_count}件"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("waitForTimeout(pauseMs) 呼び出しが2箇所未満（検出: ${waitfortimeout_count}件）")
+    echo "  NG - waitForTimeout(pauseMs) 呼び出しが2箇所未満（検出: ${waitfortimeout_count}件）"
+  fi
+fi
+
+echo ""
+echo "=== summary ==="
+echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - ${t}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/skills/demo-e2e/SKILL.md
+++ b/skills/demo-e2e/SKILL.md
@@ -41,7 +41,7 @@ E2Eテストケースカタログ（CASE_ID付きCSV。例: `e2e/playwright-test
 | パラメータ | 既定値 | 意味 |
 |-----------|-------|------|
 | slowMo | **1500ms** | 操作間の待ち。`WALKTHROUGH_SLOWMO` として `run-walkthrough.mjs` に渡す |
-| ステップ間静止秒数（`pauseMs`） | **5秒（5000ms）** | 1ステップ実行後に画面を静止させる秒数。生成する `flow.mjs` 内で `page.waitForTimeout(pauseMs)` として実現する（`run-walkthrough.mjs` 自体にはこの機能が無い） |
+| ステップ間静止秒数（`pauseMs`） | **5秒（5000ms）** | 1ステップ実行後に画面を静止させる秒数。`run-walkthrough.mjs` に `WALKTHROUGH_PAUSE_MS`（ms）として渡し、runner側で `ctx.step` / `ctx.goto` 完了直後に自動で静止させる（Issue #148。flow.mjs 側への手動挿入は不要） |
 
 既定値は実運用で好評だった値（Issue #142）。人間が「もっと速く/遅く」と要望した場合は、その回のみ `WALKTHROUGH_SLOWMO` の値・`pauseMs` の値を具体的なミリ秒数で確認したうえで上書きする（例:「もっと速く」→「slowMo を800ms、静止を2秒にしますか？」と確認してから反映する。曖昧な指定のまま数値を推測で決め打ちしない）。
 
@@ -126,23 +126,19 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 
 ### Step 2-2: flow生成・実演
 
-1. **1ケース用の `flow.mjs` を生成する**（都度の使い捨て成果物。`run-walkthrough.mjs` 自体は変更しない）。Step 2-1 の操作手順を `ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` で表現し、**`ctx.goto` / `ctx.step` の実行直後に `await ctx.page.waitForTimeout(pauseMs)` を呼んで操作ごとに画面を静止させる**（`pauseMs` は既定 5000。人間が上書きした場合はその値）。flow ファイルは絶対パス（例: スクラッチ領域配下）で保存する。
+1. **1ケース用の `flow.mjs` を生成する**（都度の使い捨て成果物。`run-walkthrough.mjs` 自体は変更しない）。Step 2-1 の操作手順を `ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` で表現する。**ステップ間の静止は `run-walkthrough.mjs` が `WALKTHROUGH_PAUSE_MS` を見て `ctx.step` / `ctx.goto` 完了直後に自動で行う**（Issue #148。flow.mjs 側に `waitForTimeout` を手で挿入する必要はない。呼び出し方は次項2参照）。flow ファイルは絶対パス（例: スクラッチ領域配下）で保存する。
 
    - **前提の再現**: `run-walkthrough.mjs` は毎回新規にブラウザ・コンテキストを起動するため（ケース間でログインセッション等の状態は引き継がれない）、Step 2-1 で言語化した前提（ログイン状態・spec の `beforeEach`/fixture 相当のセットアップ）は、そのケース専用の `flow.mjs` の中で `ctx.login()` や事前の `ctx.goto` / 操作として明示的に再現する。認証情報が異なるケースでは `ctx.login({ username, password })` で明示上書きする。まずは Phase 0 Step 0-1 のシード投入・flow内での事前操作（`ctx.page` 経由のAPI呼び出しを含む）で再現を試み、それでもなお再現不能な前提が残る場合にのみ、Step 1-3 と同様に**実行不能と判断してスキップし、理由を提示する**（安易にスキップへ倒さない）
-   - **静止のかけどころ**: `ctx.step` だけでなく、画面遷移を伴う `ctx.goto` の直後にも静止を入れ、遷移直後の画面も人間が確認できるようにする
 
    ```js
    // 生成する flow.mjs のイメージ(デモ用に都度生成する使い捨てファイル)
    export default async (ctx) => {
-     const pauseMs = 5000 // 既定5秒。人間の指定があれば上書き
      await ctx.login() // 前提: ログイン状態(spec の beforeEach 相当をここで再現)
      await ctx.goto('/checkout')
-     await ctx.page.waitForTimeout(pauseMs)
      await ctx.step('カートの商品を確認', async (page) => {
        await page.getByTestId('cart-item-1').waitFor()
      })
-     await ctx.page.waitForTimeout(pauseMs)
-     // ...ケースの手順分だけ ctx.goto/ctx.step + waitForTimeout を繰り返す
+     // ...ケースの手順分だけ ctx.goto/ctx.step を繰り返す（ステップ間の静止は WALKTHROUGH_PAUSE_MS で runner が自動付与）
    }
    ```
 
@@ -150,11 +146,13 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 
    ```bash
    WALKTHROUGH_SLOWMO=1500 \
+   WALKTHROUGH_PAUSE_MS=5000 \
    WALKTHROUGH_OUT="demo-e2e-artifacts/<SAFE_CASE_ID>/attempt-<N>" \
    node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"
    ```
 
    - `WALKTHROUGH_SLOWMO` は既定 1500ms（未上書き時）
+   - `WALKTHROUGH_PAUSE_MS` は既定 5000ms（未上書き時）。runner が `ctx.step` / `ctx.goto` 完了直後に自動で指定ms静止させる（正の整数以外は無効化＝静止しない）
    - **CASE_ID のサニタイズ（パストラバーサル対策・衝突防止）**: CASE_ID はケースカタログ由来の外部入力であり、`WALKTHROUGH_OUT` は `run-walkthrough.mjs` 内で `path.resolve()` により絶対パスへ解決されるため、CASE_ID に `../` 等の区切り文字が含まれると成果物の保存先が projectRoot 外へ移動し得る。成果物パスを組み立てる前に CASE_ID から **`<SAFE_CASE_ID>`**（ファイルシステム安全な識別子）を導出する: `[A-Za-z0-9._-]` 以外の文字を `_` に置換する。**置換が1文字でも発生した場合は、異なる CASE_ID が同じ `<SAFE_CASE_ID>` に衝突するのを防ぐため、元の CASE_ID の短い安定ハッシュ（例: `shasum` で得た先頭8文字などの決定的な値）を `-<hash>` として末尾に付加する**（例: `A/B` → `A_B-3f2a1c9d`。置換が発生しない CASE_ID はファイルシステム上そのまま安全なため、可読性を保つ目的でハッシュを付加しない）。結果が `.` または `..` になる場合は採用せず、元の CASE_ID の短い安定ハッシュから導出した固定形式の識別子（例: `case-<hash>`）にフォールバックする（連番サフィックス等カタログ順・実行順に依存する識別子は、再実行のたびに別ディレクトリへ移動し既存の `attempt-*` を検出できなくなるほか、異なる特殊な CASE_ID 同士が同じ別名に衝突し得るため使用しない）。成果物ディレクトリと `attempt-*` の既存スキャンには常に `<SAFE_CASE_ID>` のみを使い、CASE_ID そのものはパス構成に使わない。画面への実況・解説・Step 2-3 の報告では元の CASE_ID をそのまま表示する
    - `WALKTHROUGH_OUT` は**ケースの`<SAFE_CASE_ID>`を含むサブディレクトリ**を毎回指定する（成果物をケースごとに区別するため。例: `demo-e2e-artifacts/CASE-101/attempt-1/`）。実行前に `demo-e2e-artifacts/<SAFE_CASE_ID>/` 配下の既存 `attempt-*` を確認し、**最大番号の次の番号**を `attempt-<N>` として使う（同一セッション内の初回はもちろん、別セッションでの再実行・過去の実行が残っている場合でも `attempt-1` から採番し直して上書きしない）。`run-walkthrough.mjs` は同一 `WALKTHROUGH_OUT` を毎回上書きするため、この連番を付けないと前回（NGだった回を含む）の trace/スクショ/動画が消える
    - `WALKTHROUGH_OUT` は `run-walkthrough.mjs` 内で `projectRoot`（Step 0-3 で `WALKTHROUGH_PROJECT_ROOT` を明示した場合はそのサブワークスペース、無指定なら git root）を基準に絶対パスへ解決される（cwd 基準ではない）。Phase 3 で成果物の場所を報告する際は、この解決規則を踏まえた**絶対パス**（またはプロジェクトrootからの相対パスであることを明示した表記）で報告し、単に `demo-e2e-artifacts/<SAFE_CASE_ID>/...` とだけ書いて曖昧にしない

--- a/skills/demo/SKILL.md
+++ b/skills/demo/SKILL.md
@@ -68,6 +68,7 @@ dev server とテストデータを整えたうえで、**同梱スクリプト*
    - `node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"` を**プロジェクトを cwd にしたまま**実行する。
      runner は `createRequire` で（cwd の git root 起点に）プロジェクトの `@playwright/test` を解決するため、**プラグイン配下の場所から実行しても壊れない**。
    - **headed + slowMo + trace** が既定 ON。ステップ実況ログ・スクショ・動画保存も runner が行う。
+   - `WALKTHROUGH_PAUSE_MS`（任意）に正の整数msを指定すると、`ctx.step` / `ctx.goto` 完了直後に runner が自動でその時間だけ静止する（ゆっくり見せたい場合に使う）。未指定・不正値（0/負数/非数値等）の場合は静止しない＝従来どおりの挙動。
    - `BASE_URL` / `E2E_USERNAME` / `E2E_PASSWORD` は env で渡す（`E2E_*` は `/create-e2e` と共通の命名）。操作手順は `flow.mjs`（`export default async (ctx) => {...}`）に書き、`ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` を使う。flow ファイルは**絶対パス**で渡すこと（cwd 相対で解決される）。
    - **表示不可環境**（Linux で `DISPLAY` 無し等）では runner が**自動的に headless + スクショへフォールバック**する。明示制御は `WALKTHROUGH_HEADED=false`（headless）/ `WALKTHROUGH_HEADED=true`（headed 強制）。WSL の Headed は WSLg（`DISPLAY`）前提。
    - 注意: trace は入力値も記録され得る（`sources` 有効）。認証情報を含む成果物の取り扱いに注意する。

--- a/skills/demo/scripts/lib/parse-pause-ms.mjs
+++ b/skills/demo/scripts/lib/parse-pause-ms.mjs
@@ -1,0 +1,30 @@
+// parse-pause-ms.mjs
+// WALKTHROUGH_PAUSE_MS の値をパースする純粋関数。
+//
+// run-walkthrough.mjs 本体は Playwright 起動を伴うため import するだけで
+// ブラウザ起動等の副作用が走ってしまう（自動テストが困難）。この env パース処理だけを
+// 副作用の無い別モジュールに切り出すことで、scripts/tests/ の bash テストから
+// `node --input-type=module` 経由で直接検証できるようにしている（Issue #148）。
+//
+// 仕様:
+//   - 正の整数（文字列表現。1桁目が1-9、以降は0-9のみ。前後空白・符号・16進/指数表記・
+//     先頭ゼロは不可）のみ有効値として受理する
+//   - 未指定（undefined/null/空文字）・不正値（非数値・0・負数・小数・16進/指数表記・
+//     前後空白・先頭ゼロ付き等）は null を返す
+//     （呼び出し側はこれを「静止しない」＝従来挙動として扱う）
+//
+// Number(raw) による変換だけでは "0x10"（16進）・"5e3"（指数）・"+5000"（符号付き）・
+// " 5000 "（前後空白）・"0500"（先頭ゼロ）まで正の整数として受理してしまい、
+// ドキュメント上の「正の整数（文字列表現）のみ」という仕様より緩くなる
+// （特に "1e21" 等の巨大な指数表記を受理すると waitForTimeout が実質無限停止しうる）。
+// そのため文字列形式を正規表現で先に厳格化してから数値化する。
+const POSITIVE_INTEGER_STRING = /^[1-9][0-9]*$/
+
+export function parsePauseMs(raw) {
+  if (raw === undefined || raw === null || raw === '') return null
+  if (typeof raw !== 'string') return null
+  if (!POSITIVE_INTEGER_STRING.test(raw)) return null
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n <= 0) return null
+  return n
+}

--- a/skills/demo/scripts/run-walkthrough.mjs
+++ b/skills/demo/scripts/run-walkthrough.mjs
@@ -26,6 +26,8 @@
 //   E2E_PASSWORD          ログイン用パスワード
 //   WALKTHROUGH_HEADED    'false' で headless（既定: true。Linux で DISPLAY 無しなら自動 headless）
 //   WALKTHROUGH_SLOWMO    操作間の待ち(ms)（既定: 500）
+//   WALKTHROUGH_PAUSE_MS  ctx.step / ctx.goto 完了直後に静止する時間(ms)（既定: 未指定=静止しない）。
+//                         正の整数のみ有効。未指定・不正値（0/負数/非数値等）時は従来どおり静止しない
 //   WALKTHROUGH_OUT       成果物(スクショ/trace/動画)の出力先（既定: walkthrough-artifacts）
 //   WALKTHROUGH_PROJECT_ROOT  @playwright/test を解決するプロジェクトroot（既定: cwd）
 //   E2E_LOGIN_PATH        ctx.login が開くパス（既定: /login）
@@ -37,6 +39,9 @@ import { execSync } from 'node:child_process'
 import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
+// このスクリプトを単体で持ち出す/移動する場合は、同階層に lib/parse-pause-ms.mjs も
+// 一緒にコピーすること（欠落すると起動時に ERR_MODULE_NOT_FOUND で失敗する）。
+import { parsePauseMs } from './lib/parse-pause-ms.mjs'
 
 // --- プロジェクトroot を決定 ------------------------------------------------
 // setup.sh と同じく git root をフォールバックにし、2スクリプトの基準を揃える
@@ -76,6 +81,18 @@ const baseURL = process.env.BASE_URL || 'http://localhost:3000'
 const slowMoRaw = Number(process.env.WALKTHROUGH_SLOWMO ?? 500)
 const slowMo = Number.isFinite(slowMoRaw) && slowMoRaw >= 0 ? slowMoRaw : 500
 const outDir = path.resolve(projectRoot, process.env.WALKTHROUGH_OUT || 'walkthrough-artifacts')
+
+// 正の整数のみ有効。未指定・不正値時は null（＝静止しない。従来挙動を維持）
+const pauseMsRaw = process.env.WALKTHROUGH_PAUSE_MS
+const pauseMs = parsePauseMs(pauseMsRaw)
+// env が指定されているのに無効値だった場合のみ警告する（未指定時は既定の「静止しない」なので警告不要）。
+// slowMo は不正値時も常にフォールバック値をログ表示するのに対し、pauseMs は無効時に何も表示されず
+// 「静止しない」原因（未指定なのか typo による無効値なのか）が切り分けにくいための対策。
+if (pauseMsRaw !== undefined && pauseMs === null) {
+  console.warn(
+    `[runner] WALKTHROUGH_PAUSE_MS="${pauseMsRaw}" は正の整数として解釈できないため無視します（静止しません）。`,
+  )
+}
 
 // Headed 既定 ON。WALKTHROUGH_HEADED を明示していない場合のみ、
 // Linux で DISPLAY が無ければ自動で headless にフォールバックする
@@ -135,7 +152,10 @@ for (const sig of ['SIGINT', 'SIGTERM']) {
 }
 
 try {
-  log(`起動モード: ${headed ? 'headed' : 'headless'} / slowMo=${slowMo}ms / BASE_URL=${baseURL}`)
+  log(
+    `起動モード: ${headed ? 'headed' : 'headless'} / slowMo=${slowMo}ms` +
+      ` / pauseMs=${pauseMs ? `${pauseMs}ms` : 'off'} / BASE_URL=${baseURL}`,
+  )
   browser = await chromium.launch({ headless: !headed, slowMo })
   context = await browser.newContext({
     baseURL,
@@ -168,6 +188,7 @@ try {
         log(`応答ステータス ${status}（${p}）`)
       }
       await ctx.shot(`goto${p.replace(/[^a-z0-9]+/gi, '-')}`)
+      if (pauseMs) await page.waitForTimeout(pauseMs)
     },
 
     // スクショを連番で保存
@@ -189,6 +210,7 @@ try {
       step(description)
       await fn(page)
       await ctx.shot(description.slice(0, 32))
+      if (pauseMs) await page.waitForTimeout(pauseMs)
     },
 
     // env の認証情報でログイン（セレクタは env で上書き可能）


### PR DESCRIPTION
## 概要

`/demo-e2e` の Step 2-2 では、生成する `flow.mjs` 内の全 `ctx.goto`/`ctx.step` 直後に `await ctx.page.waitForTimeout(pauseMs)` を手で挿入する規則になっていた（runner にこの機能が無いため）。flow 生成のたびに挿入漏れが起きうる定型処理であり、flow.mjs の本来の役割（テスト手順の翻訳という意味作業）にボイラープレートが混ざっていた。

`skills/demo/scripts/run-walkthrough.mjs` に環境変数 `WALKTHROUGH_PAUSE_MS` を追加し、指定時は runner 側で `ctx.step` / `ctx.goto` の完了直後に自動で静止を入れるようにした。

## 実装内容

- `skills/demo/scripts/lib/parse-pause-ms.mjs`（新規）: `WALKTHROUGH_PAUSE_MS` の値をパースする純粋関数 `parsePauseMs(raw)`。正の整数（文字列表現。前後空白・符号・16進/指数表記・先頭ゼロは不可）のみ有効値として受理し、未指定・不正値は `null`（＝静止しない）
- `skills/demo/scripts/run-walkthrough.mjs`: 上記関数を import し、`ctx.goto` / `ctx.step` の完了直後（既存の `ctx.shot(...)` 呼び出しの直後）に `if (pauseMs) await page.waitForTimeout(pauseMs)` を追加。ヘッダコメントの環境変数一覧・起動ログにも `WALKTHROUGH_PAUSE_MS` を追記。env が指定されているのに無効値だった場合は `console.warn` で警告する
- `skills/demo-e2e/SKILL.md`: 入力パラメータ表の `pauseMs` 説明、Step 2-2 のflow生成規則・サンプルコードから `waitForTimeout` 手動挿入を削除し、runner呼び出し例に `WALKTHROUGH_PAUSE_MS=5000`（既定値）を追加
- `skills/demo/SKILL.md`: Phase 2 の runner 説明に `WALKTHROUGH_PAUSE_MS`（任意・ステップ間自動静止）の説明を追記
- `scripts/tests/test-run-walkthrough-pause-ms.sh`（新規）: `parsePauseMs` の単体テスト（node の ESM 動的評価経由。正の整数の受理・未指定/不正値の無効化を検証）＋ `run-walkthrough.mjs` 側の配線（import・`ctx.goto`/`ctx.step` での呼び出し）の grep ベース回帰ガード

## テストについて

`run-walkthrough.mjs` は Playwright 実行を伴うため完全な自動テストは困難（import するだけでブラウザ起動等の副作用が走る構成）。env パース部分（`WALKTHROUGH_PAUSE_MS` の正の整数のみ受理・不正値の無効化）を副作用の無い純粋関数 `parsePauseMs` に切り出し、`scripts/tests/test-run-walkthrough-pause-ms.sh` から `node --input-type=module` 経由で単体テストできるようにした。runner 側の配線（import・`ctx.goto`/`ctx.step` での呼び出し）は grep ベースの回帰ガードで検証している。

## 受け入れ基準 × 対応箇所

| # | 受け入れ基準 | 対応箇所 |
|---|---|---|
| 1 | WALKTHROUGH_PAUSE_MS 指定時、各 step/goto 後に指定ミリ秒の静止が入る | `skills/demo/scripts/run-walkthrough.mjs` の `ctx.goto`・`ctx.step`（`if (pauseMs) await page.waitForTimeout(pauseMs)`）。パースは `skills/demo/scripts/lib/parse-pause-ms.mjs` |
| 2 | 未指定時の挙動が完全に従来どおり | `parsePauseMs(undefined)` は `null` を返し `waitForTimeout` 自体呼ばれない（起動ログも `pauseMs=off` と明示）。`test-run-walkthrough-pause-ms.sh` の「未指定時は null」セクションで担保 |
| 3 | skills/demo-e2e/SKILL.md の waitForTimeout 手動挿入規則が env 渡しに置き換わる | `skills/demo-e2e/SKILL.md`（入力パラメータ表・Step 2-2・runner呼び出し例） |
| 4 | skills/demo/SKILL.md にも env の説明を追記 | `skills/demo/SKILL.md` Phase 2 |

## 品質ゲート

- `bash scripts/tests/*.sh`: 全件 pass（22ファイル、既存分含め全て green）
- `/quality-check`: `pass`（lint/typecheck はこのリポジトリに CLAUDE.md/package.json が無いため skip。test は `scripts/tests/*.sh` 全件実行で pass）
- `/self-review`: 2ラウンドで収束（round1 で8件のmedium/low指摘 → 修正 → round2 で残指摘なし）

## スコープ

`walkthrough-setup.sh` および他スキルには触れていない。

Closes #148
Refs: #142, #143