### PR TITLE
feat(demo-e2e): SAFE_CASE_ID導出のスクリプト化と runner のステップ間自動静止（#147/#148 統合昇格）

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@
 | fetch-pr-comments.sh / reply-and-resolve.sh | `scripts/specs/fetch-pr-comments.md` |
 | ci-wait.sh | `scripts/specs/ci-wait.md` |
 | worktree-setup.sh / worktree-cleanup.sh | `scripts/specs/worktree-setup.md` |
+| demo-e2e-out.sh | `scripts/specs/demo-e2e-out.md` |
 
 プラグイン内ファイル参照（Bash実行・Read・サブエージェント受け渡し等）のパス解決規約は `docs/plugin-path-conventions.md` を参照。本ファイルは scripts/ 配下の実装規約のみを扱う。
 

--- a/scripts/demo-e2e-out.sh
+++ b/scripts/demo-e2e-out.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# demo-e2e-out.sh
+# 使い方: scripts/demo-e2e-out.sh <CASE_ID>（詳細は下記参照）
+# 仕様の正本は scripts/specs/demo-e2e-out.md を参照。
+#
+# /demo-e2e（skills/demo-e2e/SKILL.md Step 2-2）の成果物パス規則（SAFE_CASE_ID導出・
+# attempt採番）を、実行のたびのLLMアドホック再実装から決定的スクリプトへ切り出したもの
+# （Issue #147）。エンコード規則は PR #146 4ラウンド目レビューで確定した「一律エンコード
+# （条件付きハッシュにしない。常にサニタイズ済み可読部+元CASE_IDのハッシュを付与）」を採用する。
+
+set -u
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh" || {
+  echo "Error: failed to source lib/common.sh" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 純粋関数（外部コマンドを起動しない）
+# ---------------------------------------------------------------------------
+
+# 前後の空白（space/tab/newline等）を取り除く。
+# `[[:space:]]` パターンマッチはロケール依存（呼び出し環境のLC_ALL/LC_CTYPE次第で
+# 全角スペース等の非ASCII文字を空白とみなすかどうかがブレる）ため、`local LC_ALL=C`
+# でこの関数の実行中のみロケールをCへ固定し、呼び出し環境に関わらず結果を決定的にする
+# （self-review指摘の回帰修正）。
+trim_whitespace() {
+  local LC_ALL=C
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# trim後に空文字なら "blank"、そうでなければ "non-blank" を返す。
+classify_case_id_blank() {
+  local case_id="$1"
+  local trimmed
+  trimmed="$(trim_whitespace "$case_id")"
+  if [ -z "$trimmed" ]; then
+    echo "blank"
+  else
+    echo "non-blank"
+  fi
+}
+
+# CASE_ID 中の [A-Za-z0-9._-] 以外の文字を "_" に置換した「サニタイズ済み可読部」を返す。
+# これ単体はファイルシステム上安全とは限らない（"."/".." 等）。安全化は
+# compute_safe_case_id 側でハッシュを常に付加することで担保する。
+# 実装上の注意（self-review指摘の回帰修正）:
+#   - 改行はsed（行単位処理）を通しても`_`に置換されず素通りするため、sedに渡す前に
+#     bashのパラメータ展開で明示的に`_`へ置換しておく（sedは行区切りとしての改行自体を
+#     パターンスペース内の文字として扱わないため、文字クラスにマッチさせられない）
+#   - ロケール依存でマルチバイト文字の置換結果がブレる（UTF-8ロケールでは1文字=1つの
+#     `_`、Cロケールでは1バイト=1つの`_`になる）ほか、不正なバイト列を含むとmacOSの
+#     sedがロケール依存で`illegal byte sequence`エラーを起こし可読部が消失しうるため、
+#     `LC_ALL=C`でバイト単位の決定的な置換に固定する（実行環境のロケール設定に
+#     safe_case_idが左右されないようにする）
+sanitize_case_id() {
+  local case_id="$1"
+  case_id="${case_id//$'\n'/_}"
+  printf '%s' "$case_id" | LC_ALL=C sed -E 's/[^A-Za-z0-9._-]/_/g'
+}
+
+# ---------------------------------------------------------------------------
+# ハッシュ・エンコード（shasum/sha256sum に依存するため副作用ありセクションに置く）
+# ---------------------------------------------------------------------------
+
+# 元のCASE_ID（サニタイズ前）のSHA-256先頭8文字（16進数小文字）を返す。
+# shasum（macOS標準）・sha256sum（coreutils）のどちらかがあれば動く
+# （両方とも同じダイジェスト値を返すためプラットフォーム間で結果が一致する）。
+compute_case_hash8() {
+  local case_id="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$case_id" | shasum -a 256 | cut -c1-8
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$case_id" | sha256sum | cut -c1-8
+  else
+    echo "Error: neither shasum nor sha256sum found in PATH" >&2
+    return 1
+  fi
+}
+
+# 一律エンコード規則（単射）: <サニタイズ済み可読部>-<元CASE_IDのハッシュ8文字>。
+# 非空の CASE_ID すべてに対して常にこの1つの規則を適用する（置換が発生した場合のみ
+# ハッシュを付けるような条件分岐にはしない。PR #146 4ラウンド目レビューで確定した仕様）。
+# サニタイズ済み可読部が同じでも、元のCASE_IDが異なればハッシュも異なるため衝突しない。
+# "." や ".." もこの規則で常にハッシュが付き自然に安全な文字列になるため、
+# 特別なフォールバック分岐は不要。
+compute_safe_case_id() {
+  local case_id="$1"
+  local sanitized hash
+  sanitized="$(sanitize_case_id "$case_id")"
+  hash="$(compute_case_hash8 "$case_id")" || return 1
+  printf '%s-%s' "$sanitized" "$hash"
+}
+
+# ---------------------------------------------------------------------------
+# プロジェクトroot解決（skills/demo/scripts/run-walkthrough.mjs の
+# resolveProjectRoot と同一規則。WALKTHROUGH_PROJECT_ROOT優先、無ければ
+# git rev-parse --show-toplevel、それも失敗すればcwd）。
+# ---------------------------------------------------------------------------
+
+resolve_project_root_raw() {
+  if [ -n "${WALKTHROUGH_PROJECT_ROOT:-}" ]; then
+    printf '%s' "$WALKTHROUGH_PROJECT_ROOT"
+    return 0
+  fi
+  local root
+  if root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    printf '%s' "$root"
+  else
+    pwd
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# attempt 採番（実ファイルシステムを参照する読み取り専用スキャン）
+# ---------------------------------------------------------------------------
+
+# <case_dir>（projectRootAbs 配下の demo-e2e-artifacts/<safe_case_id>）配下の
+# attempt-<数字> ディレクトリの最大番号+1を返す。該当ディレクトリが無い、または
+# attempt-* が1件も無ければ 1（初回）。
+# 実装上の注意（self-review指摘の回帰修正）: attempt-08 のようにゼロ埋めされた既存
+# ディレクトリ（人間の手動作成・別ツール由来等、本スクリプト以外が作った名前の可能性が
+# ある）が存在すると、bashの算術評価（`$(( ))`）は先頭ゼロの数値を8進数として解釈し
+# `08`/`09` で "value too great for base" エラーになる。`10#` プレフィックスを付けて
+# 常に10進数として解釈させる。
+compute_next_attempt() {
+  local case_dir="$1"
+  local max=0
+  if [ -d "$case_dir" ]; then
+    local d name n
+    while IFS= read -r -d '' d; do
+      name="$(basename "$d")"
+      if [[ "$name" =~ ^attempt-([0-9]+)$ ]]; then
+        n=$((10#${BASH_REMATCH[1]}))
+        if [ "$n" -gt "$max" ]; then
+          max="$n"
+        fi
+      fi
+    done < <(find "$case_dir" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+  fi
+  echo $((max + 1))
+}
+
+# ---------------------------------------------------------------------------
+# gitignore 警告（git呼び出し）
+# ---------------------------------------------------------------------------
+
+# projectRoot の .gitignore（git管理下）が demo-e2e-artifacts をカバーしていなければ
+# "true"（警告あり）、カバーしていれば "false" を返す。独自にgitignoreパターンを
+# パースせず git check-ignore に判定させる。非gitリポジトリ等で判定不能な場合は
+# 安全側に倒し "true" を返す。
+check_gitignore_warning() {
+  local project_root="$1"
+  local rc
+  git -C "$project_root" check-ignore -q "demo-e2e-artifacts" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
+print_usage() {
+  local prog
+  prog="$(basename "$0")"
+  echo "Usage: ${prog} <CASE_ID>" >&2
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+main() {
+  local case_id_raw="${1:-}"
+
+  if [ "$(classify_case_id_blank "$case_id_raw")" = "blank" ]; then
+    echo "Error: CASE_ID must not be empty or whitespace-only" >&2
+    print_usage
+    exit 1
+  fi
+
+  if ! check_jq; then
+    exit 1
+  fi
+
+  # 前後の空白は識別子の一部とみなさない（trim後の値をsafe_case_id導出にも使う。
+  # self-review指摘の回帰修正: 空判定はtrim後で行うのに導出は生値のままだと、
+  # 前後空白の有無だけで別ケース扱いになりattempt連番が分裂していた）。
+  local case_id
+  case_id="$(trim_whitespace "$case_id_raw")"
+
+  local safe_case_id
+  if ! safe_case_id="$(compute_safe_case_id "$case_id")"; then
+    exit 1
+  fi
+
+  local project_root_raw
+  project_root_raw="$(resolve_project_root_raw)"
+  if [ ! -d "$project_root_raw" ]; then
+    echo "Error: project root directory does not exist: ${project_root_raw}" >&2
+    exit 1
+  fi
+  local project_root_abs
+  project_root_abs="$(cd "$project_root_raw" && pwd)"
+
+  local case_dir="${project_root_abs}/demo-e2e-artifacts/${safe_case_id}"
+  local attempt
+  attempt="$(compute_next_attempt "$case_dir")"
+
+  local out_dir="demo-e2e-artifacts/${safe_case_id}/attempt-${attempt}"
+
+  local gitignore_warning
+  gitignore_warning="$(check_gitignore_warning "$project_root_abs")"
+
+  jq -n -c \
+    --arg safe_case_id "$safe_case_id" \
+    --arg out_dir "$out_dir" \
+    --argjson attempt "$attempt" \
+    --argjson gitignore_warning "$gitignore_warning" \
+    '{safe_case_id: $safe_case_id, out_dir: $out_dir, attempt: $attempt, gitignore_warning: $gitignore_warning}'
+}
+
+# `source` された場合は main を実行しない（テストからの関数直接呼び出しを可能にするため）。
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+  exit $?
+fi

--- a/scripts/demo-e2e-out.sh
+++ b/scripts/demo-e2e-out.sh
@@ -206,7 +206,10 @@ main() {
     exit 1
   fi
   local project_root_abs
-  project_root_abs="$(cd "$project_root_raw" && pwd)"
+  if ! project_root_abs="$(cd "$project_root_raw" && pwd)" || [ -z "$project_root_abs" ]; then
+    echo "Error: failed to resolve project root directory: ${project_root_raw}" >&2
+    exit 1
+  fi
 
   local case_dir="${project_root_abs}/demo-e2e-artifacts/${safe_case_id}"
   local attempt

--- a/scripts/specs/demo-e2e-out.md
+++ b/scripts/specs/demo-e2e-out.md
@@ -1,0 +1,34 @@
+# demo-e2e-out.sh の出力仕様（正本）
+
+`/demo-e2e`（`skills/demo-e2e/SKILL.md` Step 2-2）が成果物パス（SAFE_CASE_ID・attempt番号）を求める際に呼び出す（Issue #147）。CASE_ID のサニタイズ・衝突防止ハッシュ・attempt採番という決定的処理を、実行のたびのLLMアドホック再実装から切り出したもの。gh は呼ばない（gh非依存）。
+
+## `scripts/demo-e2e-out.sh <CASE_ID>`
+
+stdout JSON（1行・compact）:
+```json
+{"safe_case_id": "CASE-101-3f2a1c9d", "out_dir": "demo-e2e-artifacts/CASE-101-3f2a1c9d/attempt-1", "attempt": 1, "gitignore_warning": false}
+```
+
+| フィールド | 型 | 意味 |
+|---|---|---|
+| `safe_case_id` | string | CASE_ID から導出したファイルシステム安全な識別子。`<サニタイズ済み可読部>-<hash8>` 形式（下記参照） |
+| `out_dir` | string | 成果物の出力先。**projectRoot からの相対パス** `demo-e2e-artifacts/<safe_case_id>/attempt-<attempt>`（絶対パスにしない。`run-walkthrough.mjs` の `WALKTHROUGH_OUT` は projectRoot 基準の `path.resolve()` で解決される仕組みのため、相対パスのまま渡す前提と整合させる） |
+| `attempt` | number | このケースの `demo-e2e-artifacts/<safe_case_id>/` 配下に存在する `attempt-<数字>` ディレクトリの最大番号+1。該当ディレクトリが無い、または `attempt-*` が1件も無ければ `1` |
+| `gitignore_warning` | bool | projectRoot の `.gitignore`（git管理下）が `demo-e2e-artifacts` をカバーしていなければ `true` |
+
+挙動の要点:
+
+- **入力検証**: 引数が空、または空白のみ（trimして空）の場合は使用方法を stderr に出し非0 exit（stdout には何も出さない）
+- **前後空白のtrim**: CASE_ID の前後空白（space/tab/newline）は識別子の一部とみなさない。空判定だけでなく `safe_case_id` の導出にも trim 後の値を使う（同じ論理ケースが前後空白の有無だけで別の `safe_case_id`／別の attempt 系列に分裂しないようにするため）
+- **SAFE_CASE_ID のエンコード（一律・単射。PR #146 4ラウンド目レビューで確定した仕様）**: 条件付きハッシュ（置換が発生した場合のみハッシュを付ける）にはしない。trim後の非空 CASE_ID すべてに対して常に次の1つの規則を適用する:
+  1. サニタイズ済み可読部: CASE_ID 中の `[A-Za-z0-9._-]` 以外の文字を `_` に置換したもの（改行を含む。ロケール依存の揺れ・不正バイト列によるクラッシュを避けるため `LC_ALL=C` でバイト単位に固定して置換する）
+  2. 元の CASE_ID（サニタイズ前、trim後）の決定的な短いハッシュ（SHA-256 先頭8文字・16進数）を `-<hash8>` として**常に**付加する
+  3. `safe_case_id = "<サニタイズ済み可読部>-<hash8>"`
+
+  この規則により条件付き実装が不要になる: 例えば `A/B` → `A_B` + `-` + hash8("A/B")、`A_B` → `A_B` + `-` + hash8("A_B") となり、サニタイズ済み可読部が同じでもハッシュが異なるため衝突しない（単射性）。`.` や `..` も同一規則でハッシュが付くため自然に安全な文字列（`/` を含まず `.`/`..` 単体にもならない）になり、特別なフォールバック分岐は不要
+  - ハッシュは `shasum -a 256`（macOS標準）と `sha256sum`（coreutils。Linux通常同梱）の両方を試す（どちらも同じダイジェスト値を返すためプラットフォーム間で結果が一致する）。どちらも無ければ stderr にエラーを出し非0 exit。ハッシュ対象文字列は `printf '%s'`（`echo` は使わない）で渡し、末尾改行の混入で結果がブレないようにする
+- **プロジェクトroot解決**: `skills/demo/scripts/run-walkthrough.mjs` の `resolveProjectRoot` と同一規則。`WALKTHROUGH_PROJECT_ROOT` が設定されていればそれを使い、未設定なら `git rev-parse --show-toplevel`、それも失敗すれば cwd にフォールバックする。解決したパスが存在しないディレクトリの場合は非0 exit。相対パスで指定された `WALKTHROUGH_PROJECT_ROOT` にも対応するため、以降のスキャン・gitignore判定は解決したパスを起点にした絶対パスで行う
+- **attempt 採番**: 上記で解決した projectRoot 配下の `demo-e2e-artifacts/<safe_case_id>/` をスキャンし、`attempt-<数字>` ディレクトリの最大番号+1を採用する（数値として比較する。`attempt-10` は `attempt-2` より大きい。ゼロ埋め表記の `attempt-08` 等が存在しても10進数として正しく扱う）
+- **gitignore 警告**: 独自にgitignoreパターンをパースせず `git -C "<projectRoot>" check-ignore -q "demo-e2e-artifacts"` を使う。exit 0（ignore対象）なら `gitignore_warning: false`、exit 1（非対象）なら `true`。それ以外（非gitリポジトリ等の判定不能）は安全側に倒し `true`
+- jq 不在時は stderr にエラーを出し非0 exit（`scripts/lib/common.sh` の `check_jq` を使用）
+- **カタログ解決時の空/重複 CASE_ID 拒否**: 空文字列の拒否は本スクリプトが担う（上記入力検証）。重複 CASE_ID の拒否（同一カタログ内に同じ CASE_ID が複数存在する場合の実行前エラー）は本スクリプトの責務外（単一 CASE_ID を受け取る設計のため）。呼び出し元の `skills/demo-e2e/SKILL.md` Step 1-1（カタログ解決）側で扱う

--- a/scripts/tests/test-demo-e2e-out.sh
+++ b/scripts/tests/test-demo-e2e-out.sh
@@ -295,7 +295,9 @@ echo ""
 echo "=== main(): エンドツーエンド(一時gitリポジトリ) ==="
 {
   MAIN_TMP="$(mktemp -d)"
-  main_cleanup() { rm -rf "$MAIN_TMP"; unset WALKTHROUGH_PROJECT_ROOT; }
+  # chmod 000 にしたディレクトリ(cd失敗ガードのテストで使用)が残っていてもrm -rfで
+  # 確実に削除できるよう、削除前に再帰的に書き込み・実行権限を戻しておく。
+  main_cleanup() { chmod -R u+rwx "$MAIN_TMP" 2>/dev/null || true; rm -rf "$MAIN_TMP"; unset WALKTHROUGH_PROJECT_ROOT; }
   trap main_cleanup EXIT
 
   MAIN_REPO="${MAIN_TMP}/repo"
@@ -397,6 +399,26 @@ echo "=== main(): エンドツーエンド(一時gitリポジトリ) ==="
   missing_stdout="$(cd "$MAIN_REPO" && WALKTHROUGH_PROJECT_ROOT="${MAIN_TMP}/no-such-dir" bash "$TARGET_SCRIPT" "CASE-401" 2>/dev/null)" || missing_rc=$?
   assert_true "存在しないWALKTHROUGH_PROJECT_ROOT: 非0 exitで失敗する" "$([ "$missing_rc" -ne 0 ] && echo true || echo false)"
   assert_eq "存在しないWALKTHROUGH_PROJECT_ROOT: stdoutにJSONを出力しない" "" "$missing_stdout"
+
+  # cd失敗ガード(PR #151レビュー指摘の回帰): -dでの存在確認は真になるが実行権限が無く
+  # cdできないディレクトリを渡した場合、project_root_absに空文字列が入ったまま処理が
+  # 続くと case_dir が「/demo-e2e-artifacts/...」という不正なパスになり
+  # compute_next_attempt が attempt=1 を返して既存成果物を上書きしうる。cdの成否を
+  # 検査し失敗時は非0 exitにする(set -e無効環境でも退化しないことを直接検証する)。
+  NOEXEC_DIR="${MAIN_TMP}/noexec-root"
+  mkdir -p "$NOEXEC_DIR"
+  chmod 000 "$NOEXEC_DIR"
+  if (cd "$NOEXEC_DIR" 2>/dev/null); then
+    # CI環境がroot実行等の場合、chmod 000でもcdできてしまうことがあるため
+    # そのケースはこのガードの検証対象外としてskipする(誤って失敗扱いにしない)。
+    echo "  skip - 実行権限が無くcdできないWALKTHROUGH_PROJECT_ROOT(実行環境がroot等でchmod 000でもcd可能なためskip)"
+  else
+    noexec_rc=0
+    noexec_stdout="$(cd "$MAIN_REPO" && WALKTHROUGH_PROJECT_ROOT="$NOEXEC_DIR" bash "$TARGET_SCRIPT" "CASE-501" 2>/dev/null)" || noexec_rc=$?
+    assert_true "実行権限が無くcdできないWALKTHROUGH_PROJECT_ROOT: 非0 exitで失敗する" "$([ "$noexec_rc" -ne 0 ] && echo true || echo false)"
+    assert_eq "実行権限が無くcdできないWALKTHROUGH_PROJECT_ROOT: stdoutにJSONを出力しない" "" "$noexec_stdout"
+  fi
+  chmod 755 "$NOEXEC_DIR"
 
   main_cleanup
   trap - EXIT

--- a/scripts/tests/test-demo-e2e-out.sh
+++ b/scripts/tests/test-demo-e2e-out.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+# test-demo-e2e-out.sh
+# scripts/demo-e2e-out.sh の純粋関数（trim_whitespace/classify_case_id_blank/
+# sanitize_case_id/compute_case_hash8/compute_safe_case_id/compute_next_attempt/
+# resolve_project_root_raw/check_gitignore_warning）と、main() のエンドツーエンド挙動
+# （一時gitリポジトリ上での実地検証）を検証する。
+#
+# 実行方法: bash scripts/tests/test-demo-e2e-out.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SCRIPT="${SCRIPT_DIR}/../demo-e2e-out.sh"
+
+# shellcheck source=/dev/null
+source "$TARGET_SCRIPT"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+assert_eq() {
+  local description="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${description}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("$description")
+    echo "  NG - ${description}"
+    echo "       expected: ${expected}"
+    echo "       actual:   ${actual}"
+  fi
+}
+
+assert_true() {
+  local description="$1" cond="$2" # "true" or "false"
+  if [ "$cond" = "true" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${description}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("$description")
+    echo "  NG - ${description}"
+  fi
+}
+
+echo "=== trim_whitespace / classify_case_id_blank ==="
+{
+  assert_eq "trim_whitespace: 前後空白を除去" "abc" "$(trim_whitespace "  abc  ")"
+  assert_eq "trim_whitespace: タブ・空白混在も除去" "abc" "$(trim_whitespace $'\t abc \t')"
+  assert_eq "classify_case_id_blank: 空文字は blank" "blank" "$(classify_case_id_blank "")"
+  assert_eq "classify_case_id_blank: 空白のみは blank" "blank" "$(classify_case_id_blank "   ")"
+  assert_eq "classify_case_id_blank: タブのみは blank" "blank" "$(classify_case_id_blank $'\t\t')"
+  assert_eq "classify_case_id_blank: 通常値は non-blank" "non-blank" "$(classify_case_id_blank "CASE-101")"
+  assert_eq "classify_case_id_blank: 前後空白ありの通常値は non-blank" "non-blank" "$(classify_case_id_blank "  CASE-101  ")"
+  # 回帰: [[:space:]]パターンマッチがロケール依存で、全角スペース等の非ASCII空白を
+  # trimするかどうかが呼び出し環境のロケール設定次第でブレていた(self-review指摘)。
+  # trim_whitespace内でLC_ALL=Cに固定しているため、ロケール設定を変えても結果は同じになる。
+  fullwidth_space="$(printf '\xe3\x80\x80CASE-1')" # U+3000 IDEOGRAPHIC SPACE
+  trim_locale1="$(LC_ALL=en_US.UTF-8 trim_whitespace "$fullwidth_space" 2>/dev/null || true)"
+  trim_locale2="$(LC_ALL=C trim_whitespace "$fullwidth_space" 2>/dev/null || true)"
+  assert_eq "全角スペースを含む値のtrim結果は呼び出し環境のロケール設定に依存しない" "$trim_locale2" "$trim_locale1"
+}
+
+echo ""
+echo "=== sanitize_case_id ==="
+{
+  assert_eq "英数字・._-はそのまま" "CASE-101" "$(sanitize_case_id "CASE-101")"
+  assert_eq "/ は _ に置換" "A_B" "$(sanitize_case_id "A/B")"
+  assert_eq "既にファイルシステム安全な値はそのまま" "A_B" "$(sanitize_case_id "A_B")"
+  assert_eq "複数の不正文字を一括置換" ".._.._etc_passwd" "$(sanitize_case_id "../../etc/passwd")"
+  assert_eq "単体の . はそのまま(サニタイズ部のみでは判定しない)" "." "$(sanitize_case_id ".")"
+  assert_eq "単体の .. はそのまま(サニタイズ部のみでは判定しない)" ".." "$(sanitize_case_id "..")"
+  # 回帰: sedは行単位処理のため、素朴な実装だと改行が置換されず素通りしてしまう
+  # （self-reviewで検出。code-reviewer指摘）。改行も他の不正文字と同様に "_" に置換されること。
+  assert_eq "改行を含む値は改行も _ に置換される(sedの行単位処理の落とし穴を回避)" "CASE_101" "$(sanitize_case_id "$(printf 'CASE\n101')")"
+  # 回帰: ロケール依存でマルチバイト文字の置換結果がブレる問題(self-review指摘)。
+  # LC_ALL=Cに固定しているため、ロケール設定を変えても結果は同じになる。
+  hash_locale_ja1="$(LC_ALL=en_US.UTF-8 sanitize_case_id "ケース1" 2>/dev/null || true)"
+  hash_locale_ja2="$(LC_ALL=C sanitize_case_id "ケース1" 2>/dev/null || true)"
+  assert_eq "マルチバイト文字の置換結果は呼び出し環境のロケール設定に依存しない" "$hash_locale_ja2" "$hash_locale_ja1"
+}
+
+echo ""
+echo "=== compute_case_hash8 ==="
+{
+  hash1="$(compute_case_hash8 "A/B")"
+  hash2="$(compute_case_hash8 "A/B")"
+  assert_eq "同じ入力からは同じハッシュ(決定的)" "$hash1" "$hash2"
+  assert_true "8桁の16進数文字列" "$([[ "$hash1" =~ ^[0-9a-f]{8}$ ]] && echo true || echo false)"
+
+  hash_ab="$(compute_case_hash8 "A_B")"
+  assert_true "元のCASE_IDが違えばハッシュも異なる(A/B vs A_B)" "$([ "$hash1" != "$hash_ab" ] && echo true || echo false)"
+}
+
+echo ""
+echo "=== compute_safe_case_id: 単射性(一律エンコード、条件付きハッシュにしない) ==="
+{
+  safe_slash="$(compute_safe_case_id "A/B")"
+  safe_underscore="$(compute_safe_case_id "A_B")"
+  assert_true "A/B と A_B は異なる safe_case_id になる(単射性)" "$([ "$safe_slash" != "$safe_underscore" ] && echo true || echo false)"
+  assert_true "safe_case_id(A/B) は 'A_B-' で始まる(サニタイズ済み可読部+ハッシュ)" "$([[ "$safe_slash" == A_B-* ]] && echo true || echo false)"
+  assert_true "safe_case_id(A_B) も 'A_B-' で始まる(可読部が同じでもハッシュで区別)" "$([[ "$safe_underscore" == A_B-* ]] && echo true || echo false)"
+
+  # 置換が発生しない既存安全な値にも常にハッシュが付く(一律規則)
+  safe_plain="$(compute_safe_case_id "CASE-101")"
+  assert_true "置換が発生しない値にも常にハッシュが付加される" "$([[ "$safe_plain" =~ ^CASE-101-[0-9a-f]{8}$ ]] && echo true || echo false)"
+}
+
+echo ""
+echo "=== main(): 前後空白のtrim一貫性(空判定と成果物パス導出の基準を揃える) ==="
+{
+  # 回帰: main()の空判定はtrim後の値で行うのに、safe_case_id導出はtrim前の生値を
+  # 使っていたため、同じ論理ケースでも前後空白の有無だけでsafe_case_idが分裂していた
+  # (self-review指摘。code-reviewer/design-reviewer双方でCONFIRMED)。
+  TRIM_TMP="$(mktemp -d)"
+  trim_e2e_cleanup() { rm -rf "$TRIM_TMP"; }
+  trap trim_e2e_cleanup EXIT
+
+  TRIM_REPO="${TRIM_TMP}/repo"
+  mkdir -p "$TRIM_REPO"
+  (
+    cd "$TRIM_REPO" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "hello" >README.md
+    git add README.md
+    git commit -q -m "initial"
+  )
+
+  output_plain="$(cd "$TRIM_REPO" && bash "$TARGET_SCRIPT" "CASE-101")"
+  safe_plain_e2e="$(jq -r '.safe_case_id' <<<"$output_plain")"
+  # demo-e2e-out.sh 自体は成果物ディレクトリを作らない(実際に作るのは呼び出し元の
+  # run-walkthrough.mjs)ため、attempt連番の継続を検証するには前回分のディレクトリを
+  # テスト側で用意する必要がある。
+  mkdir -p "${TRIM_REPO}/demo-e2e-artifacts/${safe_plain_e2e}/attempt-1"
+
+  output_padded="$(cd "$TRIM_REPO" && bash "$TARGET_SCRIPT" "  CASE-101  ")"
+  safe_padded_e2e="$(jq -r '.safe_case_id' <<<"$output_padded")"
+  assert_eq "前後空白ありのCASE_IDも、trim後の値と同じsafe_case_idになる" "$safe_plain_e2e" "$safe_padded_e2e"
+  assert_eq "前後空白ありのCASE_IDは attempt採番でも同じケースとして扱われる(attempt=2)" "2" "$(jq -r '.attempt' <<<"$output_padded")"
+
+  trim_e2e_cleanup
+  trap - EXIT
+}
+
+echo ""
+echo "=== compute_safe_case_id: traversal安全化 ==="
+{
+  safe_dot="$(compute_safe_case_id ".")"
+  assert_true "'.' は '.' そのものにならない" "$([ "$safe_dot" != "." ] && echo true || echo false)"
+  assert_true "'.' の結果に / を含まない" "$([[ "$safe_dot" != *"/"* ]] && echo true || echo false)"
+
+  safe_dotdot="$(compute_safe_case_id "..")"
+  assert_true "'..' は '..' そのものにならない" "$([ "$safe_dotdot" != ".." ] && echo true || echo false)"
+  assert_true "'..' の結果に / を含まない" "$([[ "$safe_dotdot" != *"/"* ]] && echo true || echo false)"
+
+  safe_traversal="$(compute_safe_case_id "../../etc/passwd")"
+  assert_true "'../../etc/passwd' の結果に / を含まない" "$([[ "$safe_traversal" != *"/"* ]] && echo true || echo false)"
+  assert_true "'../../etc/passwd' は '.' でも '..' でもない" "$([ "$safe_traversal" != "." ] && [ "$safe_traversal" != ".." ] && echo true || echo false)"
+}
+
+echo ""
+echo "=== compute_next_attempt ==="
+{
+  ATTEMPT_TMP="$(mktemp -d)"
+  attempt_cleanup() { rm -rf "$ATTEMPT_TMP"; }
+  trap attempt_cleanup EXIT
+
+  no_dir_attempt="$(compute_next_attempt "${ATTEMPT_TMP}/nonexistent")"
+  assert_eq "ディレクトリが無ければ attempt=1" "1" "$no_dir_attempt"
+
+  empty_case_dir="${ATTEMPT_TMP}/empty-case"
+  mkdir -p "$empty_case_dir"
+  empty_attempt="$(compute_next_attempt "$empty_case_dir")"
+  assert_eq "attempt-*が1件も無ければ attempt=1" "1" "$empty_attempt"
+
+  case_dir="${ATTEMPT_TMP}/some-case"
+  mkdir -p "${case_dir}/attempt-1" "${case_dir}/attempt-2"
+  next_attempt="$(compute_next_attempt "$case_dir")"
+  assert_eq "attempt-1,attempt-2 が存在すれば attempt=3" "3" "$next_attempt"
+
+  # 桁の異なる番号でも数値として最大を判定する
+  mkdir -p "${case_dir}/attempt-10"
+  next_attempt2="$(compute_next_attempt "$case_dir")"
+  assert_eq "attempt-10 が存在すれば attempt=11(文字列順ではなく数値順)" "11" "$next_attempt2"
+
+  # 回帰: ゼロ埋めされたattempt-*ディレクトリ(本スクリプト以外が作った可能性がある外部状態)
+  # があると、bashの算術評価が先頭ゼロを8進数と誤解釈しエラー終了していた(self-review指摘)。
+  zero_padded_dir="${ATTEMPT_TMP}/zero-padded-case"
+  mkdir -p "${zero_padded_dir}/attempt-08" "${zero_padded_dir}/attempt-09"
+  zero_padded_attempt="$(compute_next_attempt "$zero_padded_dir")"
+  zero_padded_rc=$?
+  assert_eq "ゼロ埋めのattempt-08,attempt-09があってもエラーにならず attempt=10 になる" "10" "$zero_padded_attempt"
+  assert_eq "ゼロ埋めディレクトリ走査は正常終了する(0進数誤解釈によるエラー終了なし)" "0" "$zero_padded_rc"
+
+  attempt_cleanup
+  trap - EXIT
+}
+
+echo ""
+echo "=== resolve_project_root_raw ==="
+{
+  RESOLVE_TMP="$(mktemp -d)"
+  resolve_cleanup() { rm -rf "$RESOLVE_TMP"; unset WALKTHROUGH_PROJECT_ROOT; }
+  trap resolve_cleanup EXIT
+
+  # shellcheck disable=SC2034 # resolve_project_root_raw（sourceしたTARGET_SCRIPT側の関数）が参照する
+  WALKTHROUGH_PROJECT_ROOT="${RESOLVE_TMP}/explicit-root"
+  assert_eq "WALKTHROUGH_PROJECT_ROOT指定時はその値を返す" "${RESOLVE_TMP}/explicit-root" "$(resolve_project_root_raw)"
+  unset WALKTHROUGH_PROJECT_ROOT
+
+  GITROOT_DIR="${RESOLVE_TMP}/gitroot"
+  mkdir -p "$GITROOT_DIR"
+  (
+    cd "$GITROOT_DIR" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+  )
+  git_toplevel_physical="$(cd "$GITROOT_DIR" && git rev-parse --show-toplevel)"
+  resolved="$(cd "$GITROOT_DIR" && resolve_project_root_raw)"
+  assert_eq "未設定時はgit rev-parse --show-toplevelの結果を返す" "$git_toplevel_physical" "$resolved"
+
+  resolve_cleanup
+  trap - EXIT
+}
+
+echo ""
+echo "=== check_gitignore_warning ==="
+{
+  GI_TMP="$(mktemp -d)"
+  gi_cleanup() { rm -rf "$GI_TMP"; }
+  trap gi_cleanup EXIT
+
+  GI_REPO_COVERED="${GI_TMP}/repo-covered"
+  mkdir -p "$GI_REPO_COVERED"
+  (
+    cd "$GI_REPO_COVERED" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "demo-e2e-artifacts" >.gitignore
+    git add .gitignore
+    git commit -q -m "add gitignore"
+  )
+  assert_eq ".gitignoreがdemo-e2e-artifactsをカバー -> false(警告なし)" "false" "$(check_gitignore_warning "$GI_REPO_COVERED")"
+
+  GI_REPO_UNCOVERED="${GI_TMP}/repo-uncovered"
+  mkdir -p "$GI_REPO_UNCOVERED"
+  (
+    cd "$GI_REPO_UNCOVERED" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "node_modules" >.gitignore
+    git add .gitignore
+    git commit -q -m "add gitignore"
+  )
+  assert_eq ".gitignoreがdemo-e2e-artifactsをカバーしない -> true(警告あり)" "true" "$(check_gitignore_warning "$GI_REPO_UNCOVERED")"
+
+  GI_NON_REPO="${GI_TMP}/not-a-repo"
+  mkdir -p "$GI_NON_REPO"
+  assert_eq "gitリポジトリでない場合は安全側でtrue" "true" "$(check_gitignore_warning "$GI_NON_REPO")"
+
+  gi_cleanup
+  trap - EXIT
+}
+
+echo ""
+echo "=== main(): 空/空白のみのCASE_IDは拒否 ==="
+{
+  empty_stdout="$(bash "$TARGET_SCRIPT" "" 2>/dev/null)"
+  empty_rc=$?
+  assert_eq "空文字は非0 exit" "1" "$empty_rc"
+  assert_eq "空文字はstdoutが空" "" "$empty_stdout"
+
+  blank_stdout="$(bash "$TARGET_SCRIPT" "   " 2>/dev/null)"
+  blank_rc=$?
+  assert_eq "空白のみは非0 exit" "1" "$blank_rc"
+  assert_eq "空白のみはstdoutが空" "" "$blank_stdout"
+
+  noarg_stdout="$(bash "$TARGET_SCRIPT" 2>/dev/null)"
+  noarg_rc=$?
+  assert_eq "引数無しは非0 exit" "1" "$noarg_rc"
+  assert_eq "引数無しはstdoutが空" "" "$noarg_stdout"
+
+  usage_stderr="$(bash "$TARGET_SCRIPT" "" 2>&1 1>/dev/null)"
+  assert_true "使用方法がstderrに出力される" "$(echo "$usage_stderr" | grep -qi "usage" && echo true || echo false)"
+}
+
+echo ""
+echo "=== main(): エンドツーエンド(一時gitリポジトリ) ==="
+{
+  MAIN_TMP="$(mktemp -d)"
+  main_cleanup() { rm -rf "$MAIN_TMP"; unset WALKTHROUGH_PROJECT_ROOT; }
+  trap main_cleanup EXIT
+
+  MAIN_REPO="${MAIN_TMP}/repo"
+  mkdir -p "$MAIN_REPO"
+  (
+    cd "$MAIN_REPO" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "demo-e2e-artifacts" >.gitignore
+    git add .gitignore
+    git commit -q -m "initial"
+  )
+
+  output1="$(cd "$MAIN_REPO" && bash "$TARGET_SCRIPT" "CASE-101")"
+  rc1=$?
+  assert_eq "正常系: exit 0" "0" "$rc1"
+  assert_eq "正常系: 1行のJSONが出力される(改行を除いて1行)" "1" "$(echo "$output1" | wc -l | tr -d ' ')"
+  safe1="$(jq -r '.safe_case_id' <<<"$output1")"
+  assert_true "safe_case_id は 'CASE-101-' で始まる" "$([[ "$safe1" == CASE-101-* ]] && echo true || echo false)"
+  assert_eq "初回attempt: attempt=1" "1" "$(jq -r '.attempt' <<<"$output1")"
+  assert_eq "初回attempt: out_dirはprojectRoot相対" "demo-e2e-artifacts/${safe1}/attempt-1" "$(jq -r '.out_dir' <<<"$output1")"
+  assert_eq "gitignoreカバー済み: gitignore_warning=false" "false" "$(jq -r '.gitignore_warning' <<<"$output1")"
+
+  # 成果物ディレクトリを実際に作って再実行 -> attempt連番が進む
+  mkdir -p "${MAIN_REPO}/demo-e2e-artifacts/${safe1}/attempt-1" "${MAIN_REPO}/demo-e2e-artifacts/${safe1}/attempt-2"
+  output2="$(cd "$MAIN_REPO" && bash "$TARGET_SCRIPT" "CASE-101")"
+  assert_eq "既存attempt-1,attempt-2がある場合: attempt=3" "3" "$(jq -r '.attempt' <<<"$output2")"
+  assert_eq "既存attempt-1,attempt-2がある場合: out_dirにattempt-3" "demo-e2e-artifacts/${safe1}/attempt-3" "$(jq -r '.out_dir' <<<"$output2")"
+
+  # 単射性のエンドツーエンド確認: A/B と A_B で異なる safe_case_id
+  output_slash="$(cd "$MAIN_REPO" && bash "$TARGET_SCRIPT" "A/B")"
+  output_underscore="$(cd "$MAIN_REPO" && bash "$TARGET_SCRIPT" "A_B")"
+  safe_slash_e2e="$(jq -r '.safe_case_id' <<<"$output_slash")"
+  safe_underscore_e2e="$(jq -r '.safe_case_id' <<<"$output_underscore")"
+  assert_true "main() 経由でも A/B と A_B は異なるsafe_case_idになる" "$([ "$safe_slash_e2e" != "$safe_underscore_e2e" ] && echo true || echo false)"
+
+  # traversal安全化のエンドツーエンド確認(design-reviewer指摘): out_dirが常に
+  # demo-e2e-artifacts/ 配下(projectRoot外へ出ない)に収まることを、単体関数の
+  # 性質からの間接確認だけでなくmain()の出力そのもので直接検証する
+  output_traversal="$(cd "$MAIN_REPO" && bash "$TARGET_SCRIPT" "../../etc/passwd")"
+  out_dir_traversal="$(jq -r '.out_dir' <<<"$output_traversal")"
+  assert_true "traversal入力でもout_dirは常に demo-e2e-artifacts/ で始まる" "$([[ "$out_dir_traversal" == demo-e2e-artifacts/* ]] && echo true || echo false)"
+  # 安全性の本質は「/区切りの各セグメントが単独で '.' または '..' にならない」こと
+  # (可読部の文字列に部分文字列として ".." が含まれること自体は、単独セグメントで
+  # なければ path.resolve() 上の親ディレクトリ参照にはならないため無害)。
+  traversal_unsafe_segment="false"
+  IFS='/' read -r -a traversal_segments <<<"$out_dir_traversal"
+  for seg in "${traversal_segments[@]}"; do
+    if [ "$seg" = "." ] || [ "$seg" = ".." ]; then
+      traversal_unsafe_segment="true"
+    fi
+  done
+  assert_eq "traversal入力でもout_dirの各セグメントは単独で '.' や '..' にならない" "false" "$traversal_unsafe_segment"
+
+  # gitignore未カバーのリポジトリでは warning=true
+  MAIN_REPO_NOGITIGNORE="${MAIN_TMP}/repo-nogitignore"
+  mkdir -p "$MAIN_REPO_NOGITIGNORE"
+  (
+    cd "$MAIN_REPO_NOGITIGNORE" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    echo "hello" >README.md
+    git add README.md
+    git commit -q -m "initial"
+  )
+  output_nogi="$(cd "$MAIN_REPO_NOGITIGNORE" && bash "$TARGET_SCRIPT" "CASE-201")"
+  assert_eq "gitignore未カバー: gitignore_warning=true" "true" "$(jq -r '.gitignore_warning' <<<"$output_nogi")"
+
+  # WALKTHROUGH_PROJECT_ROOT指定時は指定ディレクトリを基準にスキャンする(gitルートとは別)
+  ALT_ROOT="${MAIN_TMP}/alt-root"
+  mkdir -p "${ALT_ROOT}/demo-e2e-artifacts"
+  # まずgitルート(MAIN_REPO)基準のsafe_case_idを求め、ALT_ROOT側に同名のattemptディレクトリを用意する
+  base_output="$(cd "$MAIN_REPO" && WALKTHROUGH_PROJECT_ROOT="$ALT_ROOT" bash "$TARGET_SCRIPT" "CASE-301")"
+  safe_301="$(jq -r '.safe_case_id' <<<"$base_output")"
+  assert_eq "WALKTHROUGH_PROJECT_ROOT指定時: 初回はattempt=1" "1" "$(jq -r '.attempt' <<<"$base_output")"
+
+  mkdir -p "${ALT_ROOT}/demo-e2e-artifacts/${safe_301}/attempt-1"
+  # MAIN_REPO(gitルート)側には同名で attempt-1..3 を先に作っておく: スキャンが誤って
+  # gitルート基準で走っていれば attempt=4 になるため、ALT_ROOT基準(attempt=2)である
+  # ことを値の差として直接検証できる(常にtrueになる自明アサーションを置かない)
+  mkdir -p "${MAIN_REPO}/demo-e2e-artifacts/${safe_301}/attempt-1" \
+           "${MAIN_REPO}/demo-e2e-artifacts/${safe_301}/attempt-2" \
+           "${MAIN_REPO}/demo-e2e-artifacts/${safe_301}/attempt-3"
+  base_output2="$(cd "$MAIN_REPO" && WALKTHROUGH_PROJECT_ROOT="$ALT_ROOT" bash "$TARGET_SCRIPT" "CASE-301")"
+  assert_eq "WALKTHROUGH_PROJECT_ROOT指定時: MAIN_REPO側にattempt-1..3があってもALT_ROOT基準でattempt=2になる(gitルート基準ならattempt=4のはず)" "2" "$(jq -r '.attempt' <<<"$base_output2")"
+
+  # 相対パスの WALKTHROUGH_PROJECT_ROOT(spec明記のサポート対象)でも、絶対パス指定と
+  # 同じ基準でスキャンされ同じattempt値になることをエンドツーエンドで検証する
+  rel_output="$(cd "$MAIN_TMP" && WALKTHROUGH_PROJECT_ROOT="./alt-root" bash "$TARGET_SCRIPT" "CASE-301")"
+  assert_eq "相対パスのWALKTHROUGH_PROJECT_ROOT: 絶対パス指定と同じALT_ROOT基準でattempt=2" "2" "$(jq -r '.attempt' <<<"$rel_output")"
+  assert_eq "相対パスのWALKTHROUGH_PROJECT_ROOT: safe_case_idも絶対パス指定時と一致" "$safe_301" "$(jq -r '.safe_case_id' <<<"$rel_output")"
+
+  # project root不在ガード(spec: 解決したパスが存在しないディレクトリの場合は非0 exit)。
+  # このガードを失うと project_root_abs が空になり attempt が常に1へ退化する
+  # (前回成果物の上書き)ため、非0 exit かつ stdout 空を main() 経由で固定する
+  missing_rc=0
+  missing_stdout="$(cd "$MAIN_REPO" && WALKTHROUGH_PROJECT_ROOT="${MAIN_TMP}/no-such-dir" bash "$TARGET_SCRIPT" "CASE-401" 2>/dev/null)" || missing_rc=$?
+  assert_true "存在しないWALKTHROUGH_PROJECT_ROOT: 非0 exitで失敗する" "$([ "$missing_rc" -ne 0 ] && echo true || echo false)"
+  assert_eq "存在しないWALKTHROUGH_PROJECT_ROOT: stdoutにJSONを出力しない" "" "$missing_stdout"
+
+  main_cleanup
+  trap - EXIT
+}
+
+echo ""
+echo "=== summary ==="
+echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - ${t}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/tests/test-run-walkthrough-pause-ms.sh
+++ b/scripts/tests/test-run-walkthrough-pause-ms.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# test-run-walkthrough-pause-ms.sh
+# skills/demo/scripts/run-walkthrough.mjs が WALKTHROUGH_PAUSE_MS をパースする際の
+# 純粋関数 parsePauseMs（skills/demo/scripts/lib/parse-pause-ms.mjs）を検証する（Issue #148）。
+#
+# run-walkthrough.mjs 本体は Playwright 起動を伴うため完全な自動テストは困難だが、
+# env パース部分（正の整数のみ受理・不正値は無効化＝静止しない）は副作用の無い
+# 純粋関数に切り出してあるため、node の ESM 動的評価経由で外部コマンドを叩かずに検証できる。
+#
+# 実行方法: bash scripts/tests/test-run-walkthrough-pause-ms.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PARSE_MODULE="${REPO_ROOT}/skills/demo/scripts/lib/parse-pause-ms.mjs"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "NG - node が見つからないためテストを実行できません"
+  exit 1
+fi
+
+if [ ! -f "$PARSE_MODULE" ]; then
+  echo "NG - ${PARSE_MODULE} が見つかりません"
+  exit 1
+fi
+
+# $1: テスト名, $2: env値をセットするか(1/0), $3: env値(セットする場合), $4: 期待値("null" または数値文字列)
+run_case() {
+  local desc="$1"
+  local set_env="$2"
+  local raw_value="$3"
+  local expected="$4"
+
+  local actual
+  if [ "$set_env" = "1" ]; then
+    actual="$(TEST_PAUSE_MS_RAW="$raw_value" node --input-type=module -e "
+      import { parsePauseMs } from '${PARSE_MODULE}';
+      const result = parsePauseMs(process.env.TEST_PAUSE_MS_RAW);
+      console.log(result === null ? 'null' : String(result));
+    " 2>&1)"
+  else
+    actual="$(node --input-type=module -e "
+      import { parsePauseMs } from '${PARSE_MODULE}';
+      const result = parsePauseMs(undefined);
+      console.log(result === null ? 'null' : String(result));
+    " 2>&1)"
+  fi
+  local node_exit=$?
+
+  if [ "$node_exit" -ne 0 ]; then
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("${desc}: node実行エラー(exit ${node_exit}): ${actual}")
+    echo "  NG - ${desc}: node実行エラー(exit ${node_exit})"
+    echo "       ${actual}"
+    return
+  fi
+
+  if [ "$actual" = "$expected" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${desc}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("${desc}: expected=${expected} actual=${actual}")
+    echo "  NG - ${desc}: expected=${expected} actual=${actual}"
+  fi
+}
+
+echo "=== parsePauseMs: 正の整数は有効値として受理される ==="
+run_case "5000（既定値相当）" 1 "5000" "5000"
+run_case "1（最小の正の整数）" 1 "1" "1"
+run_case "2000（他の正の整数）" 1 "2000" "2000"
+
+echo ""
+echo "=== parsePauseMs: 未指定時は null（＝静止しない。従来挙動） ==="
+run_case "env未指定" 0 "" "null"
+run_case "空文字" 1 "" "null"
+
+echo ""
+echo "=== parsePauseMs: 不正値は無効化され null になる ==="
+run_case "0（正の整数ではない）" 1 "0" "null"
+run_case "負数" 1 "-100" "null"
+run_case "非数値文字列" 1 "abc" "null"
+run_case "小数" 1 "500.5" "null"
+run_case "数値+単位付き文字列" 1 "5000ms" "null"
+run_case "先頭ゼロ付き数値文字列" 1 "0500" "null"
+run_case "16進表記" 1 "0x10" "null"
+run_case "指数表記" 1 "5e3" "null"
+run_case "先頭プラス符号付き" 1 "+5000" "null"
+run_case "前後に空白を含む数値文字列" 1 " 5000 " "null"
+
+echo ""
+echo "=== run-walkthrough.mjs 側の配線チェック（回帰ガード） ==="
+# parsePauseMs 単体は上記で検証済みだが、run-walkthrough.mjs 側で
+# import されていること・ctx.goto / ctx.step の完了直後に実際に
+# waitForTimeout(pauseMs) が呼ばれていることまではここまでのテストでは
+# 検証できない（run-walkthrough.mjs は Playwright 起動を伴うため import 不能）。
+# grep ベースで存在確認する（scripts/tests/test-path-conventions.sh と同じ手法）。
+RUNNER_FILE="${REPO_ROOT}/skills/demo/scripts/run-walkthrough.mjs"
+
+if [ ! -f "$RUNNER_FILE" ]; then
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILED_TESTS+=("run-walkthrough.mjs が見つかりません: ${RUNNER_FILE}")
+  echo "  NG - ${RUNNER_FILE} が見つかりません"
+else
+  # $1: テスト名, $2: 検索パターン(拡張正規表現)
+  assert_runner_contains() {
+    local desc="$1"
+    local pattern="$2"
+    if grep -qE "$pattern" "$RUNNER_FILE"; then
+      PASS_COUNT=$((PASS_COUNT + 1))
+      echo "  ok - ${desc}"
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      FAILED_TESTS+=("${desc}: パターン未検出: ${pattern}")
+      echo "  NG - ${desc}: パターン未検出"
+    fi
+  }
+
+  assert_runner_contains "parsePauseMs を lib/parse-pause-ms.mjs から import している" \
+    "import \{ parsePauseMs \} from '\./lib/parse-pause-ms\.mjs'"
+
+  waitfortimeout_count="$(grep -cE 'if \(pauseMs\) await page\.waitForTimeout\(pauseMs\)' "$RUNNER_FILE")"
+  if [ "$waitfortimeout_count" -ge 2 ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - waitForTimeout(pauseMs) 呼び出しが2箇所以上存在する(ctx.goto/ctx.step想定): ${waitfortimeout_count}件"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("waitForTimeout(pauseMs) 呼び出しが2箇所未満（検出: ${waitfortimeout_count}件）")
+    echo "  NG - waitForTimeout(pauseMs) 呼び出しが2箇所未満（検出: ${waitfortimeout_count}件）"
+  fi
+fi
+
+echo ""
+echo "=== summary ==="
+echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - ${t}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/tests/test-run-walkthrough-pause-ms.sh
+++ b/scripts/tests/test-run-walkthrough-pause-ms.sh
@@ -94,6 +94,11 @@ run_case "先頭プラス符号付き" 1 "+5000" "null"
 run_case "前後に空白を含む数値文字列" 1 " 5000 " "null"
 
 echo ""
+echo "=== parsePauseMs: Node の setTimeout 上限（2147483647ms）の境界値 ==="
+run_case "2147483647（上限ちょうど。有効値）" 1 "2147483647" "2147483647"
+run_case "2147483648（上限超過。null）" 1 "2147483648" "null"
+
+echo ""
 echo "=== run-walkthrough.mjs 側の配線チェック（回帰ガード） ==="
 # parsePauseMs 単体は上記で検証済みだが、run-walkthrough.mjs 側で
 # import されていること・ctx.goto / ctx.step の完了直後に実際に

--- a/skills/demo-e2e/SKILL.md
+++ b/skills/demo-e2e/SKILL.md
@@ -77,6 +77,7 @@ dev server とテストデータを整えたうえで、**`/demo` と同梱の P
 - 入力（$ARGUMENTS）で指定されたカタログCSVを読み、各行の CASE_ID・対象spec・screen（画面名）・status（pass/fixme等）を把握する
 - specファイル・画面名・フィルタで指定された場合は、該当するカタログ行を絞り込む
 - 各対象ケースについて、紐づく **specファイルの実コード**（該当 `test(...)` ブロックとその周辺コメント）を読む。Phase 2 の解説フェーズはこのspecコードとカタログ行を根拠にする
+- カタログ内に重複した CASE_ID がある場合は、実行に入る前にエラーとしてユーザーに提示し、カタログ側の重複が解消されるまで実行を進めない
 
 ### Step 1-2: 無指定時の提案フロー（対話）
 
@@ -142,26 +143,44 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
    }
    ```
 
-2. **runner で実演を実行する**。dev server を起動したプロジェクトを cwd のまま実行する:
+2. **成果物パスをスクリプトで決定的に求める**。CASE_ID はケースカタログ由来の外部入力であり、素朴に成果物パスへ組み込むとパストラバーサル・衝突・上書き（NG回のtrace消失）の実害につながるため、`bash "${CLAUDE_PLUGIN_ROOT}/scripts/demo-e2e-out.sh" <CASE_ID>` を毎回（実演のたびに）呼び出し、SAFE_CASE_ID導出とattempt採番を行わせる（`${CLAUDE_PLUGIN_ROOT}` は表記上のプレースホルダであり環境変数ではない。実行前に、スキル起動時の「Base directory for this skill」から解決したプラグインルートの絶対パスに置換して実行する）。出力JSON（`safe_case_id`/`out_dir`/`attempt`/`gitignore_warning`）の**フィールド定義・導出規則の正本はプラグイン配下の `scripts/specs/demo-e2e-out.md`**（ここには複製しない。Read する場合はスキル起動時の「Base directory for this skill」から `<base>/../../scripts/specs/demo-e2e-out.md` として解決する）。
+
+   - **cwd / project root**: 手順3の runner 実行と同じく、**dev server を起動したプロジェクトを cwd のまま**実行する（本スクリプトは `WALKTHROUGH_PROJECT_ROOT` 未指定時に cwd 基準の `git rev-parse --show-toplevel` をプロジェクトrootとして使うため、プラグインルート等の別ディレクトリを cwd にしたまま呼ぶと手順3と基準がずれ、既存 `attempt-*` を見落として上書きしうる）。project root を Step 0-3 で明示した場合は、この呼び出しにも同じ `WALKTHROUGH_PROJECT_ROOT` を付与する:
+
+   - **シェルクォート安全埋め込み（重要）**: CASE_ID はケースカタログ由来の外部入力（非信頼値）であり、値中に `'` やシェルメタ文字（`;`・バッククォート・`$()` 等）が入りうる。コマンド文字列へ埋め込む際は必ず、値中の各 `'` を `'\''` に置換した上で全体をシングルクォート `'` で囲むこと（ダブルクォートでの埋め込みや無加工の連結はコマンドインジェクションの余地があるため禁止。`skills/pr-merge/SKILL.md` の「シェルクォート安全埋め込み（重要）」と同一規約）。
+
+     ```bash
+     bash "${CLAUDE_PLUGIN_ROOT}/scripts/demo-e2e-out.sh" 'CASE-101'
+     # Step 0-3 で WALKTHROUGH_PROJECT_ROOT を明示した場合はそれも付与する:
+     # WALKTHROUGH_PROJECT_ROOT="<Step 0-3で明示した絶対パス>" bash "${CLAUDE_PLUGIN_ROOT}/scripts/demo-e2e-out.sh" 'CASE-101'
+     # -> {"safe_case_id":"CASE-101-3f2a1c9d","out_dir":"demo-e2e-artifacts/CASE-101-3f2a1c9d/attempt-1","attempt":1,"gitignore_warning":false}
+     # CASE_ID に ' が含まれる場合の埋め込み例（値: O'Brien-Case）:
+     #   bash "${CLAUDE_PLUGIN_ROOT}/scripts/demo-e2e-out.sh" 'O'\''Brien-Case'
+     ```
+
+   - **失敗時**: 非0 exit（CASE_ID空・jq/shasum等のコマンド不在・project root不在等）の場合は実演に進まず、stderr のエラー内容をそのままユーザーに提示する（アドホックな成果物パスへフォールバックしない）
+   - `gitignore_warning: true` の場合は、実演前にユーザーへ `.gitignore` への `demo-e2e-artifacts` 追加を提案する（成果物を誤ってコミット対象に含めないため）
+   - 画面への実況・解説・Step 2-3 の報告では常に**元の CASE_ID** をそのまま表示する（`safe_case_id` は成果物パスの構成にのみ使う）
+   - 同じケースを再実行する場合（Step 2-3「再実行」）も同じコマンドを再度呼び出す。既存の `attempt-*` を踏まえて `attempt` が自動的に1つ進むため、前回（NGだった回を含む）の成果物を上書きしない
+
+3. **runner で実演を実行する**。dev server を起動したプロジェクトを cwd のまま実行する:
 
    ```bash
    WALKTHROUGH_SLOWMO=1500 \
    WALKTHROUGH_PAUSE_MS=5000 \
-   WALKTHROUGH_OUT="demo-e2e-artifacts/<SAFE_CASE_ID>/attempt-<N>" \
+   WALKTHROUGH_OUT="<手順2で得たout_dir>" \
    node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"
    ```
 
    - `WALKTHROUGH_SLOWMO` は既定 1500ms（未上書き時）
    - `WALKTHROUGH_PAUSE_MS` は既定 5000ms（未上書き時）。runner が `ctx.step` / `ctx.goto` 完了直後に自動で指定ms静止させる（正の整数以外は無効化＝静止しない）
-   - **CASE_ID のサニタイズ（パストラバーサル対策・衝突防止）**: CASE_ID はケースカタログ由来の外部入力であり、`WALKTHROUGH_OUT` は `run-walkthrough.mjs` 内で `path.resolve()` により絶対パスへ解決されるため、CASE_ID に `../` 等の区切り文字が含まれると成果物の保存先が projectRoot 外へ移動し得る。成果物パスを組み立てる前に CASE_ID から **`<SAFE_CASE_ID>`**（ファイルシステム安全な識別子）を導出する: `[A-Za-z0-9._-]` 以外の文字を `_` に置換する。**置換が1文字でも発生した場合は、異なる CASE_ID が同じ `<SAFE_CASE_ID>` に衝突するのを防ぐため、元の CASE_ID の短い安定ハッシュ（例: `shasum` で得た先頭8文字などの決定的な値）を `-<hash>` として末尾に付加する**（例: `A/B` → `A_B-3f2a1c9d`。置換が発生しない CASE_ID はファイルシステム上そのまま安全なため、可読性を保つ目的でハッシュを付加しない）。結果が `.` または `..` になる場合は採用せず、元の CASE_ID の短い安定ハッシュから導出した固定形式の識別子（例: `case-<hash>`）にフォールバックする（連番サフィックス等カタログ順・実行順に依存する識別子は、再実行のたびに別ディレクトリへ移動し既存の `attempt-*` を検出できなくなるほか、異なる特殊な CASE_ID 同士が同じ別名に衝突し得るため使用しない）。成果物ディレクトリと `attempt-*` の既存スキャンには常に `<SAFE_CASE_ID>` のみを使い、CASE_ID そのものはパス構成に使わない。画面への実況・解説・Step 2-3 の報告では元の CASE_ID をそのまま表示する
-   - `WALKTHROUGH_OUT` は**ケースの`<SAFE_CASE_ID>`を含むサブディレクトリ**を毎回指定する（成果物をケースごとに区別するため。例: `demo-e2e-artifacts/CASE-101/attempt-1/`）。実行前に `demo-e2e-artifacts/<SAFE_CASE_ID>/` 配下の既存 `attempt-*` を確認し、**最大番号の次の番号**を `attempt-<N>` として使う（同一セッション内の初回はもちろん、別セッションでの再実行・過去の実行が残っている場合でも `attempt-1` から採番し直して上書きしない）。`run-walkthrough.mjs` は同一 `WALKTHROUGH_OUT` を毎回上書きするため、この連番を付けないと前回（NGだった回を含む）の trace/スクショ/動画が消える
-   - `WALKTHROUGH_OUT` は `run-walkthrough.mjs` 内で `projectRoot`（Step 0-3 で `WALKTHROUGH_PROJECT_ROOT` を明示した場合はそのサブワークスペース、無指定なら git root）を基準に絶対パスへ解決される（cwd 基準ではない）。Phase 3 で成果物の場所を報告する際は、この解決規則を踏まえた**絶対パス**（またはプロジェクトrootからの相対パスであることを明示した表記）で報告し、単に `demo-e2e-artifacts/<SAFE_CASE_ID>/...` とだけ書いて曖昧にしない
+   - `WALKTHROUGH_OUT` には手順2で `demo-e2e-out.sh` から得た `out_dir`（projectRoot からの相対パス）をそのまま渡す。`run-walkthrough.mjs` 内で `projectRoot`（Step 0-3 で `WALKTHROUGH_PROJECT_ROOT` を明示した場合はそのサブワークスペース、無指定なら git root。`demo-e2e-out.sh` と同一の解決規則）を基準に絶対パスへ解決される（cwd 基準ではない）。Phase 3 で成果物の場所を報告する際は、この解決規則を踏まえた**絶対パス**（またはプロジェクトrootからの相対パスであることを明示した表記）で報告し、単に `out_dir` の値だけを書いて曖昧にしない
    - `BASE_URL` / `E2E_USERNAME` / `E2E_PASSWORD` 等は `/demo` Phase 2 と同じ env 命名（`E2E_*`）で渡す
-   - project root を Step 0-3 で明示した場合は `WALKTHROUGH_PROJECT_ROOT` も付与する
+   - project root を Step 0-3 で明示した場合は `WALKTHROUGH_PROJECT_ROOT` も付与する（手順2と同じ値）
    - 表示不可環境（`DISPLAY` 無し等）では runner が自動的に headless + スクショへフォールバックする。挙動は `skills/demo/SKILL.md` Phase 2 と同一のため重複記載しない
    - **注意**: trace は入力値も記録され得る（`sources` 有効）。認証情報を含む成果物の取り扱いに注意する（詳細は本ファイル末尾の注意事項）
 
-3. 実行中は各操作の前後で一文の実況を行う（例:「これからチェックアウトボタンを押します」→ 実行 →「注文確認画面に遷移しました」）。
+4. 実行中は各操作の前後で一文の実況を行う（例:「これからチェックアウトボタンを押します」→ 実行 →「注文確認画面に遷移しました」）。
 
 ### Step 2-3: 判定（人間ゲート）
 
@@ -180,7 +199,7 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 |-----------|---------|
 | **OK** | このケースを「確認済み」として記録し、次のケースの Step 2-1 へ進む |
 | **NG + 詳細** | 問題を記録する。実装側の修正が必要な場合はその旨を伝える。人間の指示（次へ進む／このケースを打ち切る）を待つ |
-| **再実行** | 同じケースの Step 2-2 を（必要ならペースやシナリオを調整して）再実行する。`WALKTHROUGH_OUT` の `attempt-<N>` を1つ進め、前回の成果物を上書きしない |
+| **再実行** | 同じケースの Step 2-2 を（必要ならペースやシナリオを調整して）再実行する。`demo-e2e-out.sh` を再度呼び出すと `attempt` が自動的に1つ進むため、前回の成果物を上書きしない |
 
 **この判定を受け取るまで次のケースには進まない**（自動で先へ進めない）。
 
@@ -195,12 +214,12 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 
 | CASE_ID | 画面 | 判定 | 成果物（絶対パス） |
 |---------|------|------|-------------------|
-| ... | ... | OK/NG/スキップ | 実演時: {実際に解決された `demo-e2e-artifacts/<SAFE_CASE_ID>/attempt-<N>/` の絶対パス}; スキップ: — |
+| ... | ... | OK/NG/スキップ | 実演時: {手順2で得た `out_dir` が実際に解決された絶対パス}; スキップ: — |
 
 - 確認済み: N件 / NG: N件 / スキップ（fixme・無効化・実行不能）: N件（理由一覧）
 ```
 
-- 実演したケースの trace / スクリーンショット / 動画は `demo-e2e-artifacts/<SAFE_CASE_ID>/attempt-<N>/`（`WALKTHROUGH_OUT` で指定したパス。Step 2-2 の解決規則に従いプロジェクトroot基準で解決される）に保存されている（`run-walkthrough.mjs` の既存の保存機能をそのまま利用）。再実行したケースは複数の `attempt-<N>` が残るため、最終判定（OK/NG確定）に対応する回を明示する
+- 実演したケースの trace / スクリーンショット / 動画は `demo-e2e-out.sh` が返した `out_dir`（`WALKTHROUGH_OUT` に渡したパス。Step 2-2 の解決規則に従いプロジェクトroot基準で解決される）に保存されている（`run-walkthrough.mjs` の既存の保存機能をそのまま利用）。再実行したケースは複数の `attempt-<N>` が残るため、最終判定（OK/NG確定）に対応する回を明示する
 - NG となったケースは、実装側の修正 Issue 化を提案してよい
 
 ---

--- a/skills/demo-e2e/SKILL.md
+++ b/skills/demo-e2e/SKILL.md
@@ -173,7 +173,7 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
    ```
 
    - `WALKTHROUGH_SLOWMO` は既定 1500ms（未上書き時）
-   - `WALKTHROUGH_PAUSE_MS` は既定 5000ms（未上書き時）。runner が `ctx.step` / `ctx.goto` 完了直後に自動で指定ms静止させる（正の整数以外は無効化＝静止しない）
+   - `WALKTHROUGH_PAUSE_MS` は既定 5000ms（未上書き時）。runner が `ctx.step` / `ctx.goto` 完了直後に自動で指定ms静止させる（正の整数以外、および2147483647（Node の setTimeout 上限）超過は無効化＝静止しない）
    - `WALKTHROUGH_OUT` には手順2で `demo-e2e-out.sh` から得た `out_dir`（projectRoot からの相対パス）をそのまま渡す。`run-walkthrough.mjs` 内で `projectRoot`（Step 0-3 で `WALKTHROUGH_PROJECT_ROOT` を明示した場合はそのサブワークスペース、無指定なら git root。`demo-e2e-out.sh` と同一の解決規則）を基準に絶対パスへ解決される（cwd 基準ではない）。Phase 3 で成果物の場所を報告する際は、この解決規則を踏まえた**絶対パス**（またはプロジェクトrootからの相対パスであることを明示した表記）で報告し、単に `out_dir` の値だけを書いて曖昧にしない
    - `BASE_URL` / `E2E_USERNAME` / `E2E_PASSWORD` 等は `/demo` Phase 2 と同じ env 命名（`E2E_*`）で渡す
    - project root を Step 0-3 で明示した場合は `WALKTHROUGH_PROJECT_ROOT` も付与する（手順2と同じ値）

--- a/skills/demo-e2e/SKILL.md
+++ b/skills/demo-e2e/SKILL.md
@@ -59,7 +59,7 @@ E2Eテストケースカタログ（CASE_ID付きCSV。例: `e2e/playwright-test
 
 dev server とテストデータを整えたうえで、**`/demo` と同梱の Playwright(Headed) セットアップスクリプトをそのまま流用**する（複製・再実装しない）。
 
-> **スクリプトの所在（重要）**: 本スキルはプラグインとして配布されるため、スクリプトは**ユーザーのプロジェクトroot ではなく、プラグイン配下**にある。実行する際は必ず `${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/` 配下のファイルを絶対パス（引用符必須）で参照し、相対パス `skills/demo/scripts/...` では呼び出さないこと（`${CLAUDE_PLUGIN_ROOT}` は表記上のプレースホルダであり環境変数ではない。実行前に、スキル起動時の「Base directory for this skill」から解決したプラグインルートの絶対パスに置換して実行する）。`cd` はせず、**dev server を起動したプロジェクトを cwd にしたまま**スクリプトを実行する（runner は cwd の git root から `@playwright/test` を解決する）。
+> **スクリプトの所在（重要）**: 本スキルはプラグインとして配布されるため、スクリプトは**ユーザーのプロジェクトroot ではなく、プラグイン配下**にある。**walkthrough セットアップ関連スクリプト**（`walkthrough-setup.sh` / `run-walkthrough.mjs`）を実行する際は必ず `${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/` 配下のファイルを絶対パス（引用符必須）で参照し、相対パス `skills/demo/scripts/...` では呼び出さないこと（`${CLAUDE_PLUGIN_ROOT}` は表記上のプレースホルダであり環境変数ではない。実行前に、スキル起動時の「Base directory for this skill」から解決したプラグインルートの絶対パスに置換して実行する）。**成果物パス決定スクリプト（`demo-e2e-out.sh`）はこの配下ではなく、プラグインルート直下の `${CLAUDE_PLUGIN_ROOT}/scripts/` 配下**にある点に注意（Phase 2 Step 2-2 参照）。`cd` はせず、**dev server を起動したプロジェクトを cwd にしたまま**スクリプトを実行する（runner は cwd の git root から `@playwright/test` を解決する）。
 <!-- 正本: docs/plugin-path-conventions.md -->
 
 **Step 0-1（dev server / テストデータ）**: dev server をバックグラウンドで起動して `BASE_URL` を控え、カタログが前提とするシードデータを投入する
@@ -160,7 +160,7 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 
    - **失敗時**: 非0 exit（CASE_ID空・jq/shasum等のコマンド不在・project root不在等）の場合は実演に進まず、stderr のエラー内容をそのままユーザーに提示する（アドホックな成果物パスへフォールバックしない）
    - `gitignore_warning: true` の場合は、実演前にユーザーへ `.gitignore` への `demo-e2e-artifacts` 追加を提案する（成果物を誤ってコミット対象に含めないため）
-   - 画面への実況・解説・Step 2-3 の報告では常に**元の CASE_ID** をそのまま表示する（`safe_case_id` は成果物パスの構成にのみ使う）
+   - 画面への実況・解説・Step 2-3 の報告では常に**元の CASE_ID** をそのまま表示する（`safe_case_id` は成果物パスの構成にのみ使う）。ただし CASE_ID に改行や端末制御文字が含まれる場合は、表示前に可視化表記（`\n` 等）へ置換してから表示する（表・報告の体裁崩れや行偽装を防ぐための表示専用処理であり、成果物パス用の `safe_case_id` サニタイズとは別物）
    - 同じケースを再実行する場合（Step 2-3「再実行」）も同じコマンドを再度呼び出す。既存の `attempt-*` を踏まえて `attempt` が自動的に1つ進むため、前回（NGだった回を含む）の成果物を上書きしない
 
 3. **runner で実演を実行する**。dev server を起動したプロジェクトを cwd のまま実行する:
@@ -172,8 +172,8 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
    node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"
    ```
 
-   - `WALKTHROUGH_SLOWMO` は既定 1500ms（未上書き時）
-   - `WALKTHROUGH_PAUSE_MS` は既定 5000ms（未上書き時）。runner が `ctx.step` / `ctx.goto` 完了直後に自動で指定ms静止させる（正の整数以外、および2147483647（Node の setTimeout 上限）超過は無効化＝静止しない）
+   - `WALKTHROUGH_SLOWMO` は上記コマンド例のとおり本スキルの運用既定値 `1500`（ms）を明示指定している（人間が明示的に依頼した場合のみ、その回に限り値を変更する。「入力パラメータ」節参照）
+   - `WALKTHROUGH_PAUSE_MS` も同様に、上記コマンド例で本スキルの運用既定値 `5000`（ms）を明示指定している（人間が明示的に依頼した場合のみ、その回に限り値を変更する）。runner (`run-walkthrough.mjs`) 自体の契約は「env 未指定・不正値（0/負数/非数値・2147483647（Node の setTimeout 上限）超過等）なら静止しない＝従来どおりの挙動」であり（`skills/demo/SKILL.md` と同一契約）、5000ms は runner 自体の既定値ではなく本スキルが明示的に渡す運用既定値である点に注意する。runner は指定を受けた場合、`ctx.step` / `ctx.goto` 完了直後に自動でその時間だけ静止する
    - `WALKTHROUGH_OUT` には手順2で `demo-e2e-out.sh` から得た `out_dir`（projectRoot からの相対パス）をそのまま渡す。`run-walkthrough.mjs` 内で `projectRoot`（Step 0-3 で `WALKTHROUGH_PROJECT_ROOT` を明示した場合はそのサブワークスペース、無指定なら git root。`demo-e2e-out.sh` と同一の解決規則）を基準に絶対パスへ解決される（cwd 基準ではない）。Phase 3 で成果物の場所を報告する際は、この解決規則を踏まえた**絶対パス**（またはプロジェクトrootからの相対パスであることを明示した表記）で報告し、単に `out_dir` の値だけを書いて曖昧にしない
    - `BASE_URL` / `E2E_USERNAME` / `E2E_PASSWORD` 等は `/demo` Phase 2 と同じ env 命名（`E2E_*`）で渡す
    - project root を Step 0-3 で明示した場合は `WALKTHROUGH_PROJECT_ROOT` も付与する（手順2と同じ値）

--- a/skills/demo-e2e/SKILL.md
+++ b/skills/demo-e2e/SKILL.md
@@ -41,7 +41,7 @@ E2Eテストケースカタログ（CASE_ID付きCSV。例: `e2e/playwright-test
 | パラメータ | 既定値 | 意味 |
 |-----------|-------|------|
 | slowMo | **1500ms** | 操作間の待ち。`WALKTHROUGH_SLOWMO` として `run-walkthrough.mjs` に渡す |
-| ステップ間静止秒数（`pauseMs`） | **5秒（5000ms）** | 1ステップ実行後に画面を静止させる秒数。生成する `flow.mjs` 内で `page.waitForTimeout(pauseMs)` として実現する（`run-walkthrough.mjs` 自体にはこの機能が無い） |
+| ステップ間静止秒数（`pauseMs`） | **5秒（5000ms）** | 1ステップ実行後に画面を静止させる秒数。`run-walkthrough.mjs` に `WALKTHROUGH_PAUSE_MS`（ms）として渡し、runner側で `ctx.step` / `ctx.goto` 完了直後に自動で静止させる（Issue #148。flow.mjs 側への手動挿入は不要） |
 
 既定値は実運用で好評だった値（Issue #142）。人間が「もっと速く/遅く」と要望した場合は、その回のみ `WALKTHROUGH_SLOWMO` の値・`pauseMs` の値を具体的なミリ秒数で確認したうえで上書きする（例:「もっと速く」→「slowMo を800ms、静止を2秒にしますか？」と確認してから反映する。曖昧な指定のまま数値を推測で決め打ちしない）。
 
@@ -126,23 +126,19 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 
 ### Step 2-2: flow生成・実演
 
-1. **1ケース用の `flow.mjs` を生成する**（都度の使い捨て成果物。`run-walkthrough.mjs` 自体は変更しない）。Step 2-1 の操作手順を `ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` で表現し、**`ctx.goto` / `ctx.step` の実行直後に `await ctx.page.waitForTimeout(pauseMs)` を呼んで操作ごとに画面を静止させる**（`pauseMs` は既定 5000。人間が上書きした場合はその値）。flow ファイルは絶対パス（例: スクラッチ領域配下）で保存する。
+1. **1ケース用の `flow.mjs` を生成する**（都度の使い捨て成果物。`run-walkthrough.mjs` 自体は変更しない）。Step 2-1 の操作手順を `ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` で表現する。**ステップ間の静止は `run-walkthrough.mjs` が `WALKTHROUGH_PAUSE_MS` を見て `ctx.step` / `ctx.goto` 完了直後に自動で行う**（Issue #148。flow.mjs 側に `waitForTimeout` を手で挿入する必要はない。呼び出し方は次項2参照）。flow ファイルは絶対パス（例: スクラッチ領域配下）で保存する。
 
    - **前提の再現**: `run-walkthrough.mjs` は毎回新規にブラウザ・コンテキストを起動するため（ケース間でログインセッション等の状態は引き継がれない）、Step 2-1 で言語化した前提（ログイン状態・spec の `beforeEach`/fixture 相当のセットアップ）は、そのケース専用の `flow.mjs` の中で `ctx.login()` や事前の `ctx.goto` / 操作として明示的に再現する。認証情報が異なるケースでは `ctx.login({ username, password })` で明示上書きする。まずは Phase 0 Step 0-1 のシード投入・flow内での事前操作（`ctx.page` 経由のAPI呼び出しを含む）で再現を試み、それでもなお再現不能な前提が残る場合にのみ、Step 1-3 と同様に**実行不能と判断してスキップし、理由を提示する**（安易にスキップへ倒さない）
-   - **静止のかけどころ**: `ctx.step` だけでなく、画面遷移を伴う `ctx.goto` の直後にも静止を入れ、遷移直後の画面も人間が確認できるようにする
 
    ```js
    // 生成する flow.mjs のイメージ(デモ用に都度生成する使い捨てファイル)
    export default async (ctx) => {
-     const pauseMs = 5000 // 既定5秒。人間の指定があれば上書き
      await ctx.login() // 前提: ログイン状態(spec の beforeEach 相当をここで再現)
      await ctx.goto('/checkout')
-     await ctx.page.waitForTimeout(pauseMs)
      await ctx.step('カートの商品を確認', async (page) => {
        await page.getByTestId('cart-item-1').waitFor()
      })
-     await ctx.page.waitForTimeout(pauseMs)
-     // ...ケースの手順分だけ ctx.goto/ctx.step + waitForTimeout を繰り返す
+     // ...ケースの手順分だけ ctx.goto/ctx.step を繰り返す（ステップ間の静止は WALKTHROUGH_PAUSE_MS で runner が自動付与）
    }
    ```
 
@@ -150,11 +146,13 @@ Phase 1 で確定した対象ケースを**1件ずつ**、次のサイクルで�
 
    ```bash
    WALKTHROUGH_SLOWMO=1500 \
+   WALKTHROUGH_PAUSE_MS=5000 \
    WALKTHROUGH_OUT="demo-e2e-artifacts/<SAFE_CASE_ID>/attempt-<N>" \
    node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"
    ```
 
    - `WALKTHROUGH_SLOWMO` は既定 1500ms（未上書き時）
+   - `WALKTHROUGH_PAUSE_MS` は既定 5000ms（未上書き時）。runner が `ctx.step` / `ctx.goto` 完了直後に自動で指定ms静止させる（正の整数以外は無効化＝静止しない）
    - **CASE_ID のサニタイズ（パストラバーサル対策・衝突防止）**: CASE_ID はケースカタログ由来の外部入力であり、`WALKTHROUGH_OUT` は `run-walkthrough.mjs` 内で `path.resolve()` により絶対パスへ解決されるため、CASE_ID に `../` 等の区切り文字が含まれると成果物の保存先が projectRoot 外へ移動し得る。成果物パスを組み立てる前に CASE_ID から **`<SAFE_CASE_ID>`**（ファイルシステム安全な識別子）を導出する: `[A-Za-z0-9._-]` 以外の文字を `_` に置換する。**置換が1文字でも発生した場合は、異なる CASE_ID が同じ `<SAFE_CASE_ID>` に衝突するのを防ぐため、元の CASE_ID の短い安定ハッシュ（例: `shasum` で得た先頭8文字などの決定的な値）を `-<hash>` として末尾に付加する**（例: `A/B` → `A_B-3f2a1c9d`。置換が発生しない CASE_ID はファイルシステム上そのまま安全なため、可読性を保つ目的でハッシュを付加しない）。結果が `.` または `..` になる場合は採用せず、元の CASE_ID の短い安定ハッシュから導出した固定形式の識別子（例: `case-<hash>`）にフォールバックする（連番サフィックス等カタログ順・実行順に依存する識別子は、再実行のたびに別ディレクトリへ移動し既存の `attempt-*` を検出できなくなるほか、異なる特殊な CASE_ID 同士が同じ別名に衝突し得るため使用しない）。成果物ディレクトリと `attempt-*` の既存スキャンには常に `<SAFE_CASE_ID>` のみを使い、CASE_ID そのものはパス構成に使わない。画面への実況・解説・Step 2-3 の報告では元の CASE_ID をそのまま表示する
    - `WALKTHROUGH_OUT` は**ケースの`<SAFE_CASE_ID>`を含むサブディレクトリ**を毎回指定する（成果物をケースごとに区別するため。例: `demo-e2e-artifacts/CASE-101/attempt-1/`）。実行前に `demo-e2e-artifacts/<SAFE_CASE_ID>/` 配下の既存 `attempt-*` を確認し、**最大番号の次の番号**を `attempt-<N>` として使う（同一セッション内の初回はもちろん、別セッションでの再実行・過去の実行が残っている場合でも `attempt-1` から採番し直して上書きしない）。`run-walkthrough.mjs` は同一 `WALKTHROUGH_OUT` を毎回上書きするため、この連番を付けないと前回（NGだった回を含む）の trace/スクショ/動画が消える
    - `WALKTHROUGH_OUT` は `run-walkthrough.mjs` 内で `projectRoot`（Step 0-3 で `WALKTHROUGH_PROJECT_ROOT` を明示した場合はそのサブワークスペース、無指定なら git root）を基準に絶対パスへ解決される（cwd 基準ではない）。Phase 3 で成果物の場所を報告する際は、この解決規則を踏まえた**絶対パス**（またはプロジェクトrootからの相対パスであることを明示した表記）で報告し、単に `demo-e2e-artifacts/<SAFE_CASE_ID>/...` とだけ書いて曖昧にしない

--- a/skills/demo/SKILL.md
+++ b/skills/demo/SKILL.md
@@ -68,6 +68,7 @@ dev server とテストデータを整えたうえで、**同梱スクリプト*
    - `node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"` を**プロジェクトを cwd にしたまま**実行する。
      runner は `createRequire` で（cwd の git root 起点に）プロジェクトの `@playwright/test` を解決するため、**プラグイン配下の場所から実行しても壊れない**。
    - **headed + slowMo + trace** が既定 ON。ステップ実況ログ・スクショ・動画保存も runner が行う。
+   - `WALKTHROUGH_PAUSE_MS`（任意）に正の整数msを指定すると、`ctx.step` / `ctx.goto` 完了直後に runner が自動でその時間だけ静止する（ゆっくり見せたい場合に使う）。未指定・不正値（0/負数/非数値等）の場合は静止しない＝従来どおりの挙動。
    - `BASE_URL` / `E2E_USERNAME` / `E2E_PASSWORD` は env で渡す（`E2E_*` は `/create-e2e` と共通の命名）。操作手順は `flow.mjs`（`export default async (ctx) => {...}`）に書き、`ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` を使う。flow ファイルは**絶対パス**で渡すこと（cwd 相対で解決される）。
    - **表示不可環境**（Linux で `DISPLAY` 無し等）では runner が**自動的に headless + スクショへフォールバック**する。明示制御は `WALKTHROUGH_HEADED=false`（headless）/ `WALKTHROUGH_HEADED=true`（headed 強制）。WSL の Headed は WSLg（`DISPLAY`）前提。
    - 注意: trace は入力値も記録され得る（`sources` 有効）。認証情報を含む成果物の取り扱いに注意する。

--- a/skills/demo/SKILL.md
+++ b/skills/demo/SKILL.md
@@ -68,7 +68,7 @@ dev server とテストデータを整えたうえで、**同梱スクリプト*
    - `node "${CLAUDE_PLUGIN_ROOT}/skills/demo/scripts/run-walkthrough.mjs" "/絶対パス/flow.mjs"` を**プロジェクトを cwd にしたまま**実行する。
      runner は `createRequire` で（cwd の git root 起点に）プロジェクトの `@playwright/test` を解決するため、**プラグイン配下の場所から実行しても壊れない**。
    - **headed + slowMo + trace** が既定 ON。ステップ実況ログ・スクショ・動画保存も runner が行う。
-   - `WALKTHROUGH_PAUSE_MS`（任意）に正の整数msを指定すると、`ctx.step` / `ctx.goto` 完了直後に runner が自動でその時間だけ静止する（ゆっくり見せたい場合に使う）。未指定・不正値（0/負数/非数値等）の場合は静止しない＝従来どおりの挙動。
+   - `WALKTHROUGH_PAUSE_MS`（任意）に正の整数msを指定すると、`ctx.step` / `ctx.goto` 完了直後に runner が自動でその時間だけ静止する（ゆっくり見せたい場合に使う）。未指定・不正値（0/負数/非数値・2147483647超過等）の場合は静止しない＝従来どおりの挙動。
    - `BASE_URL` / `E2E_USERNAME` / `E2E_PASSWORD` は env で渡す（`E2E_*` は `/create-e2e` と共通の命名）。操作手順は `flow.mjs`（`export default async (ctx) => {...}`）に書き、`ctx.goto` / `ctx.step` / `ctx.shot` / `ctx.login` を使う。flow ファイルは**絶対パス**で渡すこと（cwd 相対で解決される）。
    - **表示不可環境**（Linux で `DISPLAY` 無し等）では runner が**自動的に headless + スクショへフォールバック**する。明示制御は `WALKTHROUGH_HEADED=false`（headless）/ `WALKTHROUGH_HEADED=true`（headed 強制）。WSL の Headed は WSLg（`DISPLAY`）前提。
    - 注意: trace は入力値も記録され得る（`sources` 有効）。認証情報を含む成果物の取り扱いに注意する。

--- a/skills/demo/scripts/lib/parse-pause-ms.mjs
+++ b/skills/demo/scripts/lib/parse-pause-ms.mjs
@@ -8,9 +8,10 @@
 //
 // 仕様:
 //   - 正の整数（文字列表現。1桁目が1-9、以降は0-9のみ。前後空白・符号・16進/指数表記・
-//     先頭ゼロは不可）のみ有効値として受理する
+//     先頭ゼロは不可）かつ 2147483647（Node の setTimeout/waitForTimeout が扱える上限。
+//     2^31-1ms）以下のみ有効値として受理する
 //   - 未指定（undefined/null/空文字）・不正値（非数値・0・負数・小数・16進/指数表記・
-//     前後空白・先頭ゼロ付き等）は null を返す
+//     前後空白・先頭ゼロ付き・2147483647 超過等）は null を返す
 //     （呼び出し側はこれを「静止しない」＝従来挙動として扱う）
 //
 // Number(raw) による変換だけでは "0x10"（16進）・"5e3"（指数）・"+5000"（符号付き）・
@@ -18,7 +19,14 @@
 // ドキュメント上の「正の整数（文字列表現）のみ」という仕様より緩くなる
 // （特に "1e21" 等の巨大な指数表記を受理すると waitForTimeout が実質無限停止しうる）。
 // そのため文字列形式を正規表現で先に厳格化してから数値化する。
+//
+// さらに、正規表現を通過した巨大な整数（例: "99999999999"）も上限チェックが無いと
+// そのまま有効値として受理してしまう。Node は setTimeout/waitForTimeout に
+// 2147483647（2^31-1）ms を超える値を渡すと警告付きで 1ms に丸めるため、
+// 巨大な WALKTHROUGH_PAUSE_MS を指定すると「静止がほぼ無くなる」想定外の挙動になる。
+// これを避けるため、数値化した後に上限（Node の setTimeout 上限）を明示的に検証する。
 const POSITIVE_INTEGER_STRING = /^[1-9][0-9]*$/
+const MAX_SET_TIMEOUT_MS = 2147483647 // 2^31 - 1（Node の setTimeout/waitForTimeout 上限）
 
 export function parsePauseMs(raw) {
   if (raw === undefined || raw === null || raw === '') return null
@@ -26,5 +34,6 @@ export function parsePauseMs(raw) {
   if (!POSITIVE_INTEGER_STRING.test(raw)) return null
   const n = Number(raw)
   if (!Number.isInteger(n) || n <= 0) return null
+  if (n > MAX_SET_TIMEOUT_MS) return null
   return n
 }

--- a/skills/demo/scripts/lib/parse-pause-ms.mjs
+++ b/skills/demo/scripts/lib/parse-pause-ms.mjs
@@ -1,0 +1,30 @@
+// parse-pause-ms.mjs
+// WALKTHROUGH_PAUSE_MS の値をパースする純粋関数。
+//
+// run-walkthrough.mjs 本体は Playwright 起動を伴うため import するだけで
+// ブラウザ起動等の副作用が走ってしまう（自動テストが困難）。この env パース処理だけを
+// 副作用の無い別モジュールに切り出すことで、scripts/tests/ の bash テストから
+// `node --input-type=module` 経由で直接検証できるようにしている（Issue #148）。
+//
+// 仕様:
+//   - 正の整数（文字列表現。1桁目が1-9、以降は0-9のみ。前後空白・符号・16進/指数表記・
+//     先頭ゼロは不可）のみ有効値として受理する
+//   - 未指定（undefined/null/空文字）・不正値（非数値・0・負数・小数・16進/指数表記・
+//     前後空白・先頭ゼロ付き等）は null を返す
+//     （呼び出し側はこれを「静止しない」＝従来挙動として扱う）
+//
+// Number(raw) による変換だけでは "0x10"（16進）・"5e3"（指数）・"+5000"（符号付き）・
+// " 5000 "（前後空白）・"0500"（先頭ゼロ）まで正の整数として受理してしまい、
+// ドキュメント上の「正の整数（文字列表現）のみ」という仕様より緩くなる
+// （特に "1e21" 等の巨大な指数表記を受理すると waitForTimeout が実質無限停止しうる）。
+// そのため文字列形式を正規表現で先に厳格化してから数値化する。
+const POSITIVE_INTEGER_STRING = /^[1-9][0-9]*$/
+
+export function parsePauseMs(raw) {
+  if (raw === undefined || raw === null || raw === '') return null
+  if (typeof raw !== 'string') return null
+  if (!POSITIVE_INTEGER_STRING.test(raw)) return null
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n <= 0) return null
+  return n
+}

--- a/skills/demo/scripts/run-walkthrough.mjs
+++ b/skills/demo/scripts/run-walkthrough.mjs
@@ -26,6 +26,8 @@
 //   E2E_PASSWORD          ログイン用パスワード
 //   WALKTHROUGH_HEADED    'false' で headless（既定: true。Linux で DISPLAY 無しなら自動 headless）
 //   WALKTHROUGH_SLOWMO    操作間の待ち(ms)（既定: 500）
+//   WALKTHROUGH_PAUSE_MS  ctx.step / ctx.goto 完了直後に静止する時間(ms)（既定: 未指定=静止しない）。
+//                         正の整数のみ有効。未指定・不正値（0/負数/非数値等）時は従来どおり静止しない
 //   WALKTHROUGH_OUT       成果物(スクショ/trace/動画)の出力先（既定: walkthrough-artifacts）
 //   WALKTHROUGH_PROJECT_ROOT  @playwright/test を解決するプロジェクトroot（既定: cwd）
 //   E2E_LOGIN_PATH        ctx.login が開くパス（既定: /login）
@@ -37,6 +39,9 @@ import { execSync } from 'node:child_process'
 import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
+// このスクリプトを単体で持ち出す/移動する場合は、同階層に lib/parse-pause-ms.mjs も
+// 一緒にコピーすること（欠落すると起動時に ERR_MODULE_NOT_FOUND で失敗する）。
+import { parsePauseMs } from './lib/parse-pause-ms.mjs'
 
 // --- プロジェクトroot を決定 ------------------------------------------------
 // setup.sh と同じく git root をフォールバックにし、2スクリプトの基準を揃える
@@ -76,6 +81,18 @@ const baseURL = process.env.BASE_URL || 'http://localhost:3000'
 const slowMoRaw = Number(process.env.WALKTHROUGH_SLOWMO ?? 500)
 const slowMo = Number.isFinite(slowMoRaw) && slowMoRaw >= 0 ? slowMoRaw : 500
 const outDir = path.resolve(projectRoot, process.env.WALKTHROUGH_OUT || 'walkthrough-artifacts')
+
+// 正の整数のみ有効。未指定・不正値時は null（＝静止しない。従来挙動を維持）
+const pauseMsRaw = process.env.WALKTHROUGH_PAUSE_MS
+const pauseMs = parsePauseMs(pauseMsRaw)
+// env が指定されているのに無効値だった場合のみ警告する（未指定時は既定の「静止しない」なので警告不要）。
+// slowMo は不正値時も常にフォールバック値をログ表示するのに対し、pauseMs は無効時に何も表示されず
+// 「静止しない」原因（未指定なのか typo による無効値なのか）が切り分けにくいための対策。
+if (pauseMsRaw !== undefined && pauseMs === null) {
+  console.warn(
+    `[runner] WALKTHROUGH_PAUSE_MS="${pauseMsRaw}" は正の整数として解釈できないため無視します（静止しません）。`,
+  )
+}
 
 // Headed 既定 ON。WALKTHROUGH_HEADED を明示していない場合のみ、
 // Linux で DISPLAY が無ければ自動で headless にフォールバックする
@@ -135,7 +152,10 @@ for (const sig of ['SIGINT', 'SIGTERM']) {
 }
 
 try {
-  log(`起動モード: ${headed ? 'headed' : 'headless'} / slowMo=${slowMo}ms / BASE_URL=${baseURL}`)
+  log(
+    `起動モード: ${headed ? 'headed' : 'headless'} / slowMo=${slowMo}ms` +
+      ` / pauseMs=${pauseMs ? `${pauseMs}ms` : 'off'} / BASE_URL=${baseURL}`,
+  )
   browser = await chromium.launch({ headless: !headed, slowMo })
   context = await browser.newContext({
     baseURL,
@@ -168,6 +188,7 @@ try {
         log(`応答ステータス ${status}（${p}）`)
       }
       await ctx.shot(`goto${p.replace(/[^a-z0-9]+/gi, '-')}`)
+      if (pauseMs) await page.waitForTimeout(pauseMs)
     },
 
     // スクショを連番で保存
@@ -189,6 +210,7 @@ try {
       step(description)
       await fn(page)
       await ctx.shot(description.slice(0, 32))
+      if (pauseMs) await page.waitForTimeout(pauseMs)
     },
 
     // env の認証情報でログイン（セレクタは env で上書き可能）

--- a/skills/demo/scripts/run-walkthrough.mjs
+++ b/skills/demo/scripts/run-walkthrough.mjs
@@ -26,7 +26,7 @@
 //   E2E_PASSWORD          ログイン用パスワード
 //   WALKTHROUGH_HEADED    'false' で headless（既定: true。Linux で DISPLAY 無しなら自動 headless）
 //   WALKTHROUGH_SLOWMO    操作間の待ち(ms)（既定: 500）
-//   WALKTHROUGH_PAUSE_MS  ctx.step / ctx.goto 完了直後に静止する時間(ms)（既定: 未指定=静止しない）。
+//   WALKTHROUGH_PAUSE_MS  ctx.step / ctx.goto 完了直後に静止する時間(ms)（既定: 未指定=静止しない。上限2147483647=Node の setTimeout 上限）。
 //                         正の整数のみ有効。未指定・不正値（0/負数/非数値等）時は従来どおり静止しない
 //   WALKTHROUGH_OUT       成果物(スクショ/trace/動画)の出力先（既定: walkthrough-artifacts）
 //   WALKTHROUGH_PROJECT_ROOT  @playwright/test を解決するプロジェクトroot（既定: cwd）


### PR DESCRIPTION
## Summary

統合ブランチ `feat/demo-e2e-hardening` から main への昇格 PR。/para-impl による直列実装（#148 → #147）2件を統合。/demo-e2e の運用を決定化・簡素化するフォローアップ（PR #146 のレビュー経緯起点）。

| PR | Issue | 内容 |
|---|---|---|
| #149 | #148 | `run-walkthrough.mjs` に環境変数 `WALKTHROUGH_PAUSE_MS`（ステップ間自動静止）を追加。パースは純粋関数 `lib/parse-pause-ms.mjs` に分離（正の整数のみ受理・未指定/不正値は従来挙動で完全後方互換）。/demo-e2e の flow.mjs への waitForTimeout 手動挿入規則を env 渡しへ置換 |
| #150 | #147 | `scripts/demo-e2e-out.sh` 新設: SAFE_CASE_ID 導出（全 CASE_ID への一律安定ハッシュ付与・単射・traversal 安全）・attempt 採番（projectRoot 基準・相対パス対応）・gitignore 警告を決定的スクリプト化し JSON 返却。仕様正本 `scripts/specs/demo-e2e-out.md`・回帰テスト67アサーション新設。SKILL.md の散文規則約30行をスクリプト呼び出しに置換 |

## Review process

- #149: touches_sensitive によりリスクゲート発動 → 3レンズ judge panel（requirement-fulfillment / security / test-validity）全員 merge 判定・blockers ゼロで自律マージ
- #150: 同 judge panel で3レンズ hold（blockers 8件）→ finding-verifier 単一懐疑者×8 の敵対的検証で **confirmed 4 / refuted 4**。confirmed 4件（クォート規約・ガード未テスト・相対パス未テスト・自明アサーション）を修正コミット 12ea449 で解消し、確認レビュー（ミュータント注入の再実測付き）で merge 判定後に自律マージ
- 品質ゲート: 全24テストスイート pass・shellcheck clean・CI green

## Test plan

- [x] `scripts/tests/` 全24スイート pass（test-demo-e2e-out.sh 67アサーション、test-run-walkthrough-pause-ms.sh 12件を含む）
- [x] ミュータント kill 実測（project root 不在ガード・相対パス対応・WALKTHROUGH_PROJECT_ROOT 基準切替）
- [x] 両 PR CI green
- [ ] main 昇格前の最終確認（人間ゲート）

Closes #147
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * E2Eデモの成果物出力に対応し、安全なケース識別、試行番号の自動採番、JSON形式での出力が可能になりました。
  * `WALKTHROUGH_PAUSE_MS` により、ステップや画面遷移後の待機時間を設定できます。
  * 再実行時も既存成果物を保持し、出力先や試行番号を確認できます。
  * 不正な設定値や危険なパスを検出し、エラーや警告を表示します。
* **ドキュメント**
  * 成果物出力の仕様、エラー処理、運用ルールを追加しました。
* **テスト**
  * 出力処理、パス検証、待機時間設定などの動作確認を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->