### PR TITLE
feat(gdd): P3 フロー統合・第1弾 — quality-check 系統（GDD期の保証索引ゲート）

### DIFF
--- a/scripts/tests/test-quality-check-gdd-gate.sh
+++ b/scripts/tests/test-quality-check-gdd-gate.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# test-quality-check-gdd-gate.sh
+# GDD P3・quality-check 系統（保証索引ゲートの統合。Issue #158）の回帰テスト。2部構成:
+#
+#  (A) 統合が依存するスクリプト契約の回帰テスト
+#      /quality-check の SKILL.md は detect-dev-phase.sh / guarantee-index-check.sh の
+#      exit code と JSON フィールドの語彙に依存して分岐する（GDD期のみ索引ゲートを発動・
+#      invalid は fail-closed で中断・exit 2 や実行不能は fail 扱い）。この契約が変わると
+#      SKILL.md 側の手順が黙って壊れるため、統合が前提にする最小契約を3面
+#      （GDD期の検査実行 / SDD期の不変 / invalid の fail-closed）のフィクスチャで固定する。
+#      各スクリプト単体の網羅は test-detect-dev-phase.sh / test-guarantee-index-check.sh の
+#      担当であり、ここでは重複させない。
+#
+#  (B) SKILL.md の契約文（正準文）の存在検査
+#      フェーズ分岐と出力契約は skills/quality-check/SKILL.md の手順として実装されている
+#      （設計判断 D-15: quality-check-runner.sh 本体は変更しない）ため、正準文が逐語で
+#      存在することを grep で検査し、手順のドリフト（更新漏れ・緩和）を機械検出する
+#      （test-skeptic-discipline.sh と同じ方式）。あわせて runner がフェーズ非依存の
+#      ままであること（D-15 の不変条件）も検査する。
+#
+# 実行方法: bash scripts/tests/test-quality-check-gdd-gate.sh
+# 失敗時は非0 exitし、失敗したテスト名を要約として出力する。
+
+# shellcheck disable=SC2016 # 正準文・フィクスチャ内のバッククォートは Markdown のリテラル
+# （SKILL.md の逐語検査対象）であり、シェル展開を意図していない
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DETECT_SCRIPT="${REPO_ROOT}/scripts/detect-dev-phase.sh"
+GIC_SCRIPT="${REPO_ROOT}/scripts/guarantee-index-check.sh"
+RUNNER_SCRIPT="${REPO_ROOT}/scripts/quality-check-runner.sh"
+SKILL_FILE="${REPO_ROOT}/skills/quality-check/SKILL.md"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "NG - jq が見つからないためテストを実行できません（検査不能を pass にはしない）" >&2
+  exit 1
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$expected" = "$actual" ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${description}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("$description")
+    echo "  NG - ${description}"
+    echo "       expected: ${expected}"
+    echo "       actual:   ${actual}"
+  fi
+}
+
+# SKILL.md に正準文（固定文字列）が逐語で存在することを検査する。
+assert_skill_contains() {
+  local description="$1" phrase="$2"
+  if grep -qF -- "$phrase" "$SKILL_FILE"; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  ok - ${description}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("$description")
+    echo "  NG - ${description}"
+    echo "       file:   ${SKILL_FILE}"
+    echo "       phrase: ${phrase}"
+  fi
+}
+
+TMP_ROOT="$(mktemp -d)"
+# shellcheck disable=SC2329 # trap 経由で呼ばれるため直接呼び出しが無くても false positive
+cleanup_tmp_root() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup_tmp_root EXIT
+
+# ---------------------------------------------------------------------------
+# フィクスチャ: 導入先プロジェクトを模したワークスペース
+# ---------------------------------------------------------------------------
+
+WS="${TMP_ROOT}/project"
+mkdir -p "${WS}/docs" "${WS}/tests"
+
+# 索引ゲートの参照先になる実在テストファイル
+cat >"${WS}/tests/example.test.sh" <<'EOF'
+test_contact_returns_400() {
+  echo "sample test body"
+}
+EOF
+
+# 健全な台帳（全参照が実在）
+cat >"${WS}/docs/guarantees-ok.md" <<'EOF'
+# 保証台帳
+
+## 保証（Guarantees）
+
+### G-158-1: サンプルの保証
+
+- 種別: API契約
+- テスト: `tests/example.test.sh::test_contact_returns_400`
+- 宣言元: #158
+
+## Gaps（テストのない公開面）
+EOF
+
+# 部分的に壊れた台帳（1件は健全・1件は参照先ファイルが無い）
+cat >"${WS}/docs/guarantees-broken.md" <<'EOF'
+# 保証台帳
+
+## 保証（Guarantees）
+
+### G-158-1: サンプルの保証
+
+- 種別: API契約
+- テスト: `tests/example.test.sh::test_contact_returns_400`
+- 宣言元: #158
+
+### G-158-2: 壊れた参照を持つ保証
+
+- 種別: API契約
+- テスト: `tests/missing.test.sh::test_never_exists`
+- 宣言元: #158
+
+## Gaps（テストのない公開面）
+EOF
+
+# 「保証」節を持たない壊れた台帳（検査不能ケース）
+cat >"${WS}/docs/guarantees-no-section.md" <<'EOF'
+# 保証台帳
+
+## メモ
+
+- 節名が規約と異なる
+EOF
+
+claude_md_gdd() {
+  printf '# プロジェクト\n\n## 開発フェーズ\n\n- **フェーズ**: GDD期\n- 駆動文書: docs/guarantees.md\n'
+}
+
+claude_md_sdd_declared() {
+  printf '# プロジェクト\n\n## 開発フェーズ\n\n- **フェーズ**: SDD期\n'
+}
+
+claude_md_no_declaration() {
+  printf '# プロジェクト\n\n## 技術スタック\n\n- bash\n'
+}
+
+claude_md_invalid() {
+  printf '# プロジェクト\n\n## 開発フェーズ\n\n- **フェーズ**: GDD\n'
+}
+
+# ---------------------------------------------------------------------------
+# (A-1) SDD期の不変: 発動判定が sdd を返し、追加ゲートは発動しない
+# ---------------------------------------------------------------------------
+echo "=== (A-1) SDD期の不変: 発動判定が sdd を返す ==="
+
+claude_md_no_declaration >"${WS}/CLAUDE.md"
+out="$(bash "$DETECT_SCRIPT" "${WS}/CLAUDE.md" 2>/dev/null)"
+code=$?
+assert_eq "宣言なし: exit 0（SDD期として確定）" "0" "$code"
+assert_eq "宣言なし: phase は sdd（guarantee_index ゲートを発動しない入力）" \
+  "sdd" "$(printf '%s' "$out" | jq -r '.phase')"
+
+claude_md_sdd_declared >"${WS}/CLAUDE.md"
+out="$(bash "$DETECT_SCRIPT" "${WS}/CLAUDE.md" 2>/dev/null)"
+code=$?
+assert_eq "SDD期宣言: exit 0" "0" "$code"
+assert_eq "SDD期宣言: phase は sdd" "sdd" "$(printf '%s' "$out" | jq -r '.phase')"
+
+# SDD期の最終出力は runner の JSON そのもの（guarantee_index フィールドは存在しない）。
+# runner の出力に guarantee_index が混入しないことは (B) の D-15 不変条件検査で固定し、
+# ここでは runner の出力スキーマがトップレベル {result, auto_fix, gates} のままである
+# ことを確認する（フィールドが増えると SDD期の「挙動完全不変」が破れる）。
+out="$(cd "$WS" && bash "$RUNNER_SCRIPT" --test "true" 2>/dev/null)"
+code=$?
+assert_eq "runner 単体: exit 0（pass）" "0" "$code"
+assert_eq "runner 単体: トップレベルのフィールドは result/auto_fix/gates のみ（SDD期の出力不変）" \
+  "auto_fix,gates,result" "$(printf '%s' "$out" | jq -r 'keys | sort | join(",")')"
+
+# ---------------------------------------------------------------------------
+# (A-2) GDD期の検査実行: 発動判定が gdd を返し、索引ゲートが実行できる
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (A-2) GDD期の検査実行: gdd 判定と索引ゲートの実行 ==="
+
+claude_md_gdd >"${WS}/CLAUDE.md"
+out="$(bash "$DETECT_SCRIPT" "${WS}/CLAUDE.md" 2>/dev/null)"
+code=$?
+assert_eq "GDD期宣言: exit 0" "0" "$code"
+assert_eq "GDD期宣言: phase は gdd（guarantee_index ゲートを発動する入力）" \
+  "gdd" "$(printf '%s' "$out" | jq -r '.phase')"
+
+out="$(bash "$GIC_SCRIPT" "${WS}/docs/guarantees-ok.md" --base "$WS" 2>/dev/null)"
+code=$?
+assert_eq "健全な台帳: exit 0" "0" "$code"
+assert_eq "健全な台帳: status は pass" "pass" "$(printf '%s' "$out" | jq -r '.status')"
+assert_eq "健全な台帳: broken は 0 件" "0" "$(printf '%s' "$out" | jq -r '.counts.broken')"
+
+# 部分成功≠完全成功: 健全な参照が1件あっても、壊れた参照が1件でもあれば fail
+out="$(bash "$GIC_SCRIPT" "${WS}/docs/guarantees-broken.md" --base "$WS" 2>/dev/null)"
+code=$?
+assert_eq "部分的に壊れた台帳: exit 1（部分成功を成功にしない）" "1" "$code"
+assert_eq "部分的に壊れた台帳: status は fail" "fail" "$(printf '%s' "$out" | jq -r '.status')"
+assert_eq "部分的に壊れた台帳: broken に壊れた参照が列挙される" \
+  "G-158-2" "$(printf '%s' "$out" | jq -r '.broken[0].guarantee_id')"
+assert_eq "部分的に壊れた台帳: reason が特定されている" \
+  "test_file_not_found" "$(printf '%s' "$out" | jq -r '.broken[0].reason')"
+
+# ---------------------------------------------------------------------------
+# (A-3) invalid の fail-closed: 不正宣言は sdd に化けず exit 1 / phase invalid
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (A-3) invalid の fail-closed: 不正宣言は sdd へフォールバックしない ==="
+
+claude_md_invalid >"${WS}/CLAUDE.md"
+out="$(bash "$DETECT_SCRIPT" "${WS}/CLAUDE.md" 2>/dev/null)"
+code=$?
+assert_eq "不正宣言: exit 1（quality-check は中断して要人間判定にする入力）" "1" "$code"
+assert_eq "不正宣言: phase は invalid（sdd に読み替え不可）" \
+  "invalid" "$(printf '%s' "$out" | jq -r '.phase')"
+
+# ---------------------------------------------------------------------------
+# (A-4) 検査不能≠0件: 索引ゲートが検査できないとき pass を出力しない
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (A-4) 検査不能≠0件: 索引ゲートの実行前提欠落は pass にならない ==="
+
+# stdout（空を含む）に status:pass が現れないことを判定するヘルパ。
+# 「stdout が空」も「pass が出ていない」として no-pass 側に倒す（検査不能を pass にしない）。
+stdout_pass_marker() {
+  if printf '%s' "$1" | grep -qE '"status":[[:space:]]*"pass"'; then
+    echo "pass"
+  else
+    echo "no-pass"
+  fi
+}
+
+out="$(bash "$GIC_SCRIPT" "${WS}/docs/guarantees-missing.md" --base "$WS" 2>/dev/null)"
+code=$?
+assert_eq "台帳ファイルが無い: exit 2（SKILL.md はこれを fail 扱いにする）" "2" "$code"
+assert_eq "台帳ファイルが無い: stdout に status:pass の JSON を出力しない" \
+  "no-pass" "$(stdout_pass_marker "$out")"
+
+out="$(bash "$GIC_SCRIPT" "${WS}/docs/guarantees-no-section.md" --base "$WS" 2>/dev/null)"
+code=$?
+assert_eq "「保証」節が無い台帳: exit 2（全保証が黙って未検査になる素通りを防ぐ）" "2" "$code"
+assert_eq "「保証」節が無い台帳: stdout に status:pass の JSON を出力しない" \
+  "no-pass" "$(stdout_pass_marker "$out")"
+
+# ---------------------------------------------------------------------------
+# (B) SKILL.md の契約文（正準文）の存在検査
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== (B) SKILL.md の契約文の存在検査 ==="
+
+# GDD期の検査実行（発動判定と索引ゲートがランチャー形式で記載されている）
+assert_skill_contains "発動判定はランチャー経由の detect-dev-phase" \
+  "claude-harness-run detect-dev-phase"
+assert_skill_contains "索引ゲートはランチャー経由の guarantee-index-check" \
+  "claude-harness-run guarantee-index-check"
+assert_skill_contains "索引ゲートは gdd 判定のときだけ実行する" \
+  '手順2の判定が `gdd` の場合のみ実行する'
+assert_skill_contains "フェーズ判定はスクリプト出力のみ（CLAUDE.md を独自に grep しない）" \
+  '`CLAUDE.md` を自分で grep しない'
+
+# SDD期の不変（default-OFF）
+assert_skill_contains "SDD期は guarantee_index フィールド自体を出力しない" \
+  '`guarantee_index` フィールド自体を出力に含めない'
+assert_skill_contains "SDD期の挙動・出力は従来と完全に同一" \
+  "本スキルの挙動・最終出力は従来と完全に同一"
+
+# invalid の fail-closed
+assert_skill_contains "invalid を sdd に読み替えない" \
+  '`sdd` に読み替えない'
+assert_skill_contains "invalid は中断して要人間判定として報告する" \
+  "要人間判定"
+
+# 検査不能≠0件（スキップへの変換禁止）
+assert_skill_contains "索引ゲートの実行不能は skip/pass に変換しない" \
+  'スキップ（`skip`）や `pass` に変換しない'
+
+# 部分成功≠完全成功（出力契約）
+assert_skill_contains "索引ゲート失敗が result:pass に見える経路を作らない" \
+  '索引ゲートの失敗が `result: "pass"` に見える出力経路は存在させない'
+assert_skill_contains "総合 result は runner pass かつ guarantee_index pass のときのみ pass" \
+  '「手順3の runner の `result` が `"pass"`」かつ「`guarantee_index.status` が `"pass"`」の場合のみ'
+
+# D-15 の不変条件: runner 本体はフェーズ非依存のまま（quality-check-runner.sh に
+# フェーズ判定・索引ゲートを組み込まない。組み込むと SDD期の出力不変が破れる）
+runner_phase_hits="$(grep -nE "guarantee_index|guarantee-index-check|detect-dev-phase" "$RUNNER_SCRIPT")"
+runner_phase_exit=$?
+if [ "$runner_phase_exit" -ge 2 ]; then
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILED_TESTS+=("runner フェーズ非依存チェックの grep 実行に失敗")
+  echo "  NG - grep 実行エラー（exit ${runner_phase_exit}）のため判定不能"
+elif [ -n "$runner_phase_hits" ]; then
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILED_TESTS+=("quality-check-runner.sh にフェーズ依存の記述が混入（D-15 違反）")
+  echo "  NG - quality-check-runner.sh にフェーズ依存の記述が混入（D-15 違反）"
+  echo "       ${runner_phase_hits}"
+else
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "  ok - quality-check-runner.sh はフェーズ非依存のまま（D-15 の不変条件）"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== summary ==="
+echo "pass: ${PASS_COUNT}, fail: ${FAIL_COUNT}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - ${t}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/skills/quality-check/SKILL.md
+++ b/skills/quality-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-check
-description: "auto-fix→lint→型チェック→テストを順に実行し、必須ゲート通過を機械可読な結果で返す品質ゲートチェック。Triggers on: '/quality-check', '品質チェック', 'QCして', 'quality gate'"
+description: "auto-fix→lint→型チェック→テストを順に実行し、必須ゲート通過を機械可読な結果で返す品質ゲートチェック。GDD期のプロジェクトでは保証索引ゲートも検査する。Triggers on: '/quality-check', '品質チェック', 'QCして', 'quality gate'"
 model: sonnet
 # effort: auto-fix は機械的範囲のみ（型/テスト失敗の修正は呼び出し元が担う）ため low。
 effort: low
@@ -8,11 +8,16 @@ effort: low
 
 # 品質ゲートチェック
 
-プロジェクトの **自動修正 → lint → 型チェック → テスト** を順に実行し、**必須ゲート**（Lint・型チェック・テストのパス）を通します。結果は人間向けサマリーと、呼び出し元が判定に使える機械可読な形式の両方で返します。
+プロジェクトの **自動修正 → lint → 型チェック → テスト** を順に実行し、**必須ゲート**（Lint・型チェック・テストのパス）を通します。**GDD期**のプロジェクト（開発フェーズの判定は手順2）では、これに**保証索引ゲート**（保証台帳のテスト対応索引の整合検査。手順4）が加わります。結果は人間向けサマリーと、呼び出し元が判定に使える機械可読な形式の両方で返します。
 
-> 必須ゲートにはこのほか「セルフレビュー」「CI」も含まれますが、本スキルはそのうち自動実行できる Lint / 型チェック / テストの3点を担います。
+> 必須ゲートにはこのほか「セルフレビュー」「CI」も含まれますが、本スキルはそのうち自動実行できる Lint / 型チェック / テスト（GDD期はさらに保証索引）を担います。
 
 ## 手順
+
+> **スクリプトの実行形（重要・本スキルが実行する全スクリプト共通）**: 本スキルはプラグインとして配布されるため、実行するスクリプト（`detect-dev-phase` / `quality-check-runner` / `guarantee-index-check`）は**ユーザーのプロジェクトroot ではなく、プラグイン配下**にある。スクリプトを実行する際は必ず PATH 上のランチャー経由で `claude-harness-run <スクリプト名>` の形式（パス・バージョン・引用符を付けない。この形だけが `Bash(claude-harness-run:*)` の1行で allowlist できる）を用い、相対パス `scripts/<スクリプト名>.sh` では呼び出さないこと。`claude-harness-run: command not found` になった場合のみ `bash "<プラグインルート>/scripts/<スクリプト名>.sh"` にフォールバックする（パスは引用符で囲む。プラグインルートはスキル起動時の「Base directory for this skill」から解決した絶対パス。`${CLAUDE_PLUGIN_ROOT}` は表記上のプレースホルダであり環境変数ではない）。フォールバックした場合はユーザーにランチャー導入を案内すること。
+<!-- 正本: docs/plugin-path-conventions.md -->
+
+> **単独コマンドとして実行する（重要・全スクリプト共通）**: 各スクリプトは上記の形のまま、**シェル変数へ代入せず**（`RESULT=$(…)` としない）、**同じ Bash 呼び出しに後続コマンドを繋げない**（`; echo "$RESULT"` や `jq … <<<"$RESULT"` を続けない）こと。ローカル変数を展開する後続コマンドがあると、permission の静的解析が「解析不能」と判定して allowlist 到達前に拒否され、headless 実行が止まる（実測済み）。stdout の JSON と exit code は **Bash ツールの実行結果からそのまま読む**。
 
 ### 1. プロジェクト設定の確認（コマンド特定）
 
@@ -23,14 +28,27 @@ CLAUDE.md および `package.json` 等から、以下のコマンドを特定す
 - 型チェックコマンド
 - テストコマンド
 
-該当するコマンドが存在しないものは省略する（次ステップのスクリプトが「スキップ」として扱い、失敗とはしない）。
+該当するコマンドが存在しないものは省略する（手順3のスクリプトが「スキップ」として扱い、失敗とはしない）。
 
-### 2. quality-check-runner.sh の実行
+### 2. 開発フェーズの判定（GDD 追加ゲートの発動判定）
 
-**自動修正の事前適用 → lint → 型チェック → テストの順序実行**、exit code に基づく `gates.*.status` 判定、機械可読 JSON の構築は、決定的な処理として `scripts/quality-check-runner.sh` に切り出されている。
+開発フェーズ（SDD期 / GDD期）によって実行するゲートと最終出力の形が変わるため、先に判定する。判定は決定的スクリプトに切り出されており、フェーズは必ずこのスクリプトの出力だけで判定し、`CLAUDE.md` を自分で grep しないこと（判定規約の重複実装を防ぐため）:
 
-> **スクリプトの実行形（重要）**: 本スキルはプラグインとして配布されるため、スクリプトは**ユーザーのプロジェクトroot ではなく、プラグイン配下**にある。スクリプトを実行する際は必ず PATH 上のランチャー経由で `claude-harness-run quality-check-runner` の形式（パス・バージョン・引用符を付けない。この形だけが `Bash(claude-harness-run:*)` の1行で allowlist できる）を用い、相対パス `scripts/quality-check-runner.sh` では呼び出さないこと。`claude-harness-run: command not found` になった場合のみ `bash "<プラグインルート>/scripts/quality-check-runner.sh"` にフォールバックする（パスは引用符で囲む。プラグインルートはスキル起動時の「Base directory for this skill」から解決した絶対パス。`${CLAUDE_PLUGIN_ROOT}` は表記上のプレースホルダであり環境変数ではない）。フォールバックした場合はユーザーにランチャー導入を案内すること。
-<!-- 正本: docs/plugin-path-conventions.md -->
+```bash
+claude-harness-run detect-dev-phase
+```
+
+stdout に `{"phase":"sdd"|"gdd"|"invalid","reason":"...","source":"..."|null}` が1個返る。
+
+| 判定結果 | 扱い |
+|---|---|
+| `phase: "sdd"`（exit 0） | 従来どおり手順3→手順5へ進む。手順4は**実行しない**。SDD期・フェーズ宣言なしのプロジェクトでは本スキルの挙動・最終出力は従来と完全に同一 |
+| `phase: "gdd"`（exit 0） | 手順3のあと手順4の保証索引ゲートを実行する |
+| `phase: "invalid"`（exit 1）／スクリプト実行不能・stdout が JSON としてパース不能 | **実行エラー**として扱う（品質 fail ではない）。`sdd` に読み替えない。**手順3以降に進まず中断**し、`reason`・`source`・stderr のメッセージを添えて「要人間判定」として報告する（不正な宣言や実行失敗によって GDD のゲート群が暗黙に無効化される事故を防ぐ。宣言の修正は人間の責務であり、エージェントが `CLAUDE.md` を書き換えて解消しない） |
+
+### 3. quality-check-runner.sh の実行
+
+**自動修正の事前適用 → lint → 型チェック → テストの順序実行**、exit code に基づく `gates.*.status` 判定、機械可読 JSON の構築は、決定的な処理として `scripts/quality-check-runner.sh` に切り出されている。開発フェーズによらず常に実行する（このスクリプト自体はフェーズを判定・解釈しない）。
 
 ```bash
 claude-harness-run quality-check-runner \
@@ -41,24 +59,42 @@ claude-harness-run quality-check-runner \
   --test "<テストコマンド>"
 ```
 
-> **単独コマンドとして実行する（重要）**: 上記の形のまま、**シェル変数へ代入せず**（`RESULT=$(…)` としない）、**同じ Bash 呼び出しに後続コマンドを繋げない**（`; echo "$RESULT"` や `jq … <<<"$RESULT"` を続けない）こと。ローカル変数を展開する後続コマンドがあると、permission の静的解析が「解析不能」と判定して allowlist 到達前に拒否され、headless 実行が止まる（実測済み）。stdout の JSON と exit code は **Bash ツールの実行結果からそのまま読む**。
-
 - 手順1で特定できなかったコマンドは、対応する `--auto-fix`/`--lint`/`--typecheck`/`--test` フラグごと省略する（0個以上の `--auto-fix` を検出順に指定。`--lint`/`--typecheck`/`--test` は1回のみ指定可）
-- 各コマンドの生出力（lintエラー箇所・型エラー内容・失敗テストの詳細）は stderr に転記される。**手順4の失敗分析はこの stderr 出力を使う**
+- 各コマンドの生出力（lintエラー箇所・型エラー内容・失敗テストの詳細）は stderr に転記される。**手順6の失敗分析はこの stderr 出力を使う**
 
 **実行結果の解釈（品質結果と実行エラーを混同しない）**: 品質判定に使ってよいのは **stdout が妥当な JSON としてパースできた場合だけ**。次の順で判定する:
 
-1. **stdout が空、または JSON としてパースできない** → **実行エラー**として扱う（品質 fail ではない）。stderr のメッセージをそのまま報告し、**手順3以降に進まず中断する**。原因は主に次の2系統:
+1. **stdout が空、または JSON としてパースできない** → **実行エラー**として扱う（品質 fail ではない）。stderr のメッセージをそのまま報告し、**手順4以降に進まず中断する**。原因は主に次の2系統:
    - **ランチャー段階の失敗**（`quality-check-runner` が起動される前に終了。exit `69` = プラグインルート／実行系を解決できない、`66` = target が見つからない、`64` = 引数不正、`command not found` = ランチャー未導入）。この場合は上記注記のフォールバック形を試し、ランチャー導入をユーザーに案内する
    - **runner 段階の失敗**（exit `2` = jq 不在、exit `1` + 空 stdout = CLI引数不正）
 2. **stdout が妥当な JSON** → 品質結果として解釈する。exit code は `result` が `pass` なら 0、`fail` なら 1
    - JSON の `result` と exit code が食い違う場合は**実行エラー扱い**とし、暗黙に pass へ倒さない
 
-出力 JSON の**フィールド定義と件数抽出の仕様の正本は、プラグイン配下の `scripts/specs/quality-check-runner.md`**（ここには複製しない）。**cwd 起点の相対パス `scripts/specs/quality-check-runner.md` では導入先プロジェクトの同名ファイルを誤って参照しうるため、Read する場合はスキル起動時の「Base directory for this skill」を起点に `<base>/../../scripts/specs/quality-check-runner.md` として解決すること。
+出力 JSON の**フィールド定義と件数抽出の仕様の正本は、プラグイン配下の `scripts/specs/quality-check-runner.md`**（ここには複製しない。手順4の `guarantee_index` は runner の出力には含まれず、この正本の対象外）。**cwd 起点の相対パス `scripts/specs/quality-check-runner.md` では導入先プロジェクトの同名ファイルを誤って参照しうるため、Read する場合はスキル起動時の「Base directory for this skill」を起点に `<base>/../../scripts/specs/quality-check-runner.md` として解決すること。
 
-### 3. 結果サマリー
+### 4. 保証索引ゲートの実行（GDD期のみ）
 
-手順2で得た stdout の JSON（`{result, auto_fix, gates: {lint, typecheck, test}}`）を最後に**機械可読な結果としてそのまま出力**する（呼び出し元のスキル/エージェントが判定に使う）。
+手順2の判定が `gdd` の場合のみ実行する（`sdd` では本手順を実行せず、手順5の最終出力に `guarantee_index` フィールド自体を出力に含めない）。保証台帳（既定: `docs/guarantees.md`）のテスト対応索引の整合を決定的スクリプトで検査する:
+
+```bash
+claude-harness-run guarantee-index-check
+```
+
+出力 JSON（`{status, ledger, base, counts, broken}`）のフィールド定義の正本はプラグイン配下の `scripts/specs/guarantee-index-check.md`（Read する場合は「Base directory for this skill」を起点に `<base>/../../scripts/specs/guarantee-index-check.md` として解決）。
+
+実行結果は次のとおり `guarantee_index` フィールド（手順5で最終出力に格納する値）へ変換する:
+
+- **exit 0 または 1 で、stdout が妥当な JSON**（`status` が `"pass"` / `"fail"`）→ その JSON を**そのまま** `guarantee_index` とする。JSON の `status` と exit code が食い違う場合（`status: "pass"` なのに exit 1 等）は次項の fail 扱いに倒し、暗黙に pass へ倒さない
+- **exit 2（台帳が読めない・「保証」節が無い・jq 不在）／stdout が空または JSON としてパース不能／スクリプト実行不能** → `guarantee_index` を `{"status": "fail", "error": "<stderr のメッセージ>"}` とする。**スキップ（`skip`）や `pass` に変換しない**（検査不能は「問題0件」と同じではない。GDD期の宣言があるのに台帳が無い・読めない状態は、索引ゲートを素通りさせず fail として呼び出し元に見せる）
+
+> 手順3の runner と異なり、本手順の実行不能は**中断ではなく fail 扱いで手順5へ進む**（runner の品質結果と索引ゲートの結果を1つの最終出力にまとめて呼び出し元へ返すため）。
+
+### 5. 結果サマリー
+
+最終出力の機械可読 JSON は開発フェーズ（手順2）で形が決まる。**機械可読な結果として最後にそのまま出力**する（呼び出し元のスキル/エージェントが判定に使う）:
+
+- **SDD期**: 手順3で得た stdout の JSON（`{result, auto_fix, gates}`）を**そのまま**出力する（従来どおり。`guarantee_index` フィールド自体を出力に含めない。`null` や `skip` 値で足すこともしない）
+- **GDD期**: `{result, auto_fix, gates, guarantee_index}`。`auto_fix`・`gates` は手順3の値、`guarantee_index` は手順4の値をそのまま格納する。**トップレベル `result` は「手順3の runner の `result` が `"pass"`」かつ「`guarantee_index.status` が `"pass"`」の場合のみ `"pass"`、それ以外は `"fail"`** とする（一部ゲートのみの成功を全体の成功として報告しない。**索引ゲートの失敗が `result: "pass"` に見える出力経路は存在させない**）
 
 あわせて `gates.*` の内容から**人間向けサマリー**（✅ パス / ❌ 失敗 / ⊘ スキップ）を組み立てて提示する:
 
@@ -73,15 +109,22 @@ claude-harness-run quality-check-runner \
 | リント | ✅/❌/⊘ | errors, warnings |
 | 型チェック | ✅/❌/⊘ | errors |
 | テスト | ✅/❌/⊘ | passed/failed/skipped |
+| 保証索引 (GDD期のみ) | ✅/❌ | guarantees, refs, broken の件数（実行不能時は error の内容） |
 
 ### 総合判定: ✅ PASS / ❌ FAIL
 ```
 
-### 4. 失敗時の対応
+（保証索引の行は GDD期のみ表示する。SDD期は従来どおり3行の表とし、⊘ スキップ行としても表示しない）
+
+### 6. 失敗時の対応
 
 `gates.*.status` が `fail` のゲートがある場合:
 1. スクリプト実行時に stderr へ転記された生出力（`--- <gate>: <cmd> ---` 区切り）からエラー内容を分析
 2. 修正方法を提案
-3. ユーザーの指示に応じて修正を実施し、手順2から再実行
+3. ユーザーの指示に応じて修正を実施し、手順3から再実行
+
+`guarantee_index.status` が `fail` の場合（GDD期）:
+1. `broken` の各 `{guarantee_id, ref, reason}` から、保証台帳のテスト参照とテスト側（ファイルパス・テスト名）のどちらを直すべきかを分析する。`broken` が無く `error` のみの場合は、stderr の内容から実行不能の原因（台帳の欠落・「保証」節の欠落等）を特定して報告する（台帳の新設・正本化は人間の裁可事項であり、本スキルでは行わない）
+2. ユーザーの指示に応じて修正を実施し、手順3から再実行する（テスト側を修正した場合はテストゲートにも影響するため、索引チェックだけの再実行にしない）
 
 > 自律実行コンテキスト（feature-implementer などのサブエージェント呼び出し）では、呼び出し元が機械可読な結果を見て修正ループを管理する。


### PR DESCRIPTION
Refs #158

## スコープ

Issue #158（GDD P3 フロー統合）のうち **quality-check 系統のみ**の部分実装（`docs/gdd-design-draft.md` §5.5・D-15）。P3 を1本の PR にせず、影響の小さい系統から分割して入れる方針のため **Closes にはしない**。残系統（create-ticket 保証節 / para-impl・feature-implementer の保証ブリーフ / promote-verify 保証整合 / define-feature の GDD 挙動）は後続の委譲で実装する。

## 変更内容

- `skills/quality-check/SKILL.md`
  - 手順2「開発フェーズの判定」を追加（`claude-harness-run detect-dev-phase` の出力のみで判定。CLAUDE.md の独自 grep は禁止）
  - 手順4「保証索引ゲート」を追加（**GDD期のみ** `claude-harness-run guarantee-index-check` を実行）
  - 手順5の最終出力契約を拡張: GDD期は `{result, auto_fix, gates, guarantee_index}`。**トップレベル `result` は runner が pass かつ `guarantee_index.status` が pass のときのみ pass**（索引ゲート失敗が `result: "pass"` に見える出力経路を作らない）
  - 手順6に `guarantee_index` 失敗時の対応（`broken` の `{guarantee_id, ref, reason}` からの修正手順）を追加
  - スクリプト実行形の注記を3スクリプト共通の形に一般化（ランチャー経由・単独コマンド実行の既存規約を踏襲）
- `scripts/tests/test-quality-check-gdd-gate.sh`（新規）
  - (A) 統合が依存するスクリプト契約の3面回帰テスト: **GDD期の検査実行**（gdd 判定→索引ゲート実行。部分的に壊れた台帳は健全な参照が残っていても fail）／**SDD期の不変**（sdd 判定・runner 出力のトップレベルフィールドが `result/auto_fix/gates` のまま）／**invalid の fail-closed**（exit 1・phase invalid）
  - (A-4) 検査不能≠0件: 台帳欠落・「保証」節欠落は exit 2 で `status: "pass"` を出力しないことを固定
  - (B) SKILL.md の正準文の逐語存在検査（`test-skeptic-discipline.sh` と同方式）+ **runner がフェーズ非依存のまま**であることの検査（D-15 不変条件）
- **`scripts/quality-check-runner.sh` は無変更**（D-15）。バージョン bump も含めない（P3 完了後にまとめて実施の方針）

## SDD期不変の担保方法（default-OFF）

- SDD期（宣言なし含む）は手順4を実行せず、最終出力は runner の stdout JSON **そのまま**（`guarantee_index` フィールド自体を出力しない。`null`/`skip` でも足さない）。人間向けサマリーも従来と同じ3行の表
- テストで二重に固定: (A-1) が runner 出力のトップレベルフィールド不変を、(B) が「SDD期は `guarantee_index` フィールド自体を出力に含めない」「本スキルの挙動・最終出力は従来と完全に同一」の正準文と runner のフェーズ非依存（`detect-dev-phase`/`guarantee_index` への言及ゼロ）を検査

## 置いた仮定・設計判断

1. **invalid 宣言時は quality-check 全体を中断**（lint/test も実行せず「実行エラー・要人間判定」として報告）。§2.1 D-16「フェーズ依存の処理を停止」と guarantee-audit（P2）の「停止する」に合わせた。フェーズ不明のまま出すと「必要なゲートを含まない pass」が成立しうるため、runner 実行前に止める形を採用
2. **detect-dev-phase 自体が実行不能（jq 不在等）の場合も中断**。宣言なしワークスペースでは従来動いていた分の退行に見えるが、jq 不在なら runner も exit 2 で実行エラーになるため実質的な挙動差はない（fail-closed を優先）
3. **feature-implementer 側の `guarantee_index.broken` 消費手順（§5.5 の反復ループ記述）は本 PR に含めない**。feature-implementer は既に `/quality-check` の `result` を見て反復する汎用ループを持ち、GDD ゲートの失敗も `result: "fail"` として安全側に流れる。明示的な消費手順は para-impl / feature-implementer 系統（§5.4）の後続委譲で扱う
4. **索引ゲートの実行不能は中断ではなく `{status:"fail", error}` で手順5へ進む**（D-15 の明文どおり。runner の品質結果と併せて1つの最終出力で返す）。索引チェックの `status` と exit code の食い違いも fail 扱い（runner の同種規約と対称）
5. GDD期に台帳（`docs/guarantees.md`）が存在しない場合は fail（skip にしない）。台帳の新設・正本化は人間の裁可事項としスキルでは行わない
6. SKILL.md frontmatter の description に GDD 言及を1文追加（トリガー条件は不変更）

## 品質ゲート結果

- `scripts/tests/` 全29ファイル pass（新規 test-quality-check-gdd-gate.sh は33アサーション pass）
- shellcheck: 指摘の増減なし（main: 27件 → 本ブランチ: 27件。新規ファイル単体は指摘0）

## 未検証事項

- 導入先プロジェクトでの LLM による実際の手順実行（フェーズ分岐・JSON 合算のプロンプト追従）は実機 headless 実行では未検証。決定的部分（スクリプト契約・正準文）はテストで固定済み
- 本リポジトリの PR に CI は付かないため CI 待機はしない（運用どおり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 開発フェーズを判定し、GDDフェーズでは保証索引ゲートを実行する品質チェックに対応しました。
  * 品質チェック結果をフェーズごとのJSONで確認できるようになりました。
  * 実行エラーや検査不能な状態を適切に判定し、安全側で失敗するようになりました。

* **ドキュメント**
  * 品質チェックの実行方法、ランチャー経由の利用、フォールバック手順、失敗時の対応を明記しました。

* **テスト**
  * 成功・部分失敗・検査不能・不正なフェーズ判定を検証する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->